### PR TITLE
ユーザ関連の修正 Feature/user modification 01

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -84,4 +84,14 @@
       color: #fa812b;
     }
   }
+  #error_explanation {
+    margin-bottom: 10px;
+    padding: 8px;
+    background-color: rgba($color: #f27e93, $alpha: 0.8);
+    border-radius: 10px;
+    border: solid #f24130;
+    .error {
+      color: yellow;
+    }
+  }
 }

--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -12,6 +12,7 @@
     box-shadow: 0 0 8px 0 #aee6e6;
   }
 }
+// **** ボタン用ミックスイン ****
 @mixin submit-layout($bgColor, $hoverColor, $boxShadow) {
   min-width: 130px;
   height: 50px;
@@ -54,6 +55,11 @@
   input[type='submit'] {
     @include submit-layout(#ffa45b, #fa812b, #fa8d35);
   }
+  .texearea-box {
+    @include input-layout;
+    width: 100%;
+    height: 250px;
+  }
   .login-link {
     display: inline-block;
     margin: 20px 0 10px 0;
@@ -74,20 +80,8 @@
   .back-link {
     color: #ffa45b;
     font-weight: bold;
-    position: relative;
-    padding-left: 10px;
-    &::before {
-      position: absolute;
-      content: '';
-      width: 6px;
-      height: 6px;
-      border-top: solid 2px #697b91;
-      border-right: solid 2px #697b91;
-      -webkit-transform: rotate(0.62turn);
-      transform: rotate(0.62turn);
-      top: 50%;
-      left: 0;
-      margin-top: -3px;
+    &:hover {
+      color: #fa812b;
     }
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,9 @@ class User < ApplicationRecord
   has_many :makes, dependent: :destroy
   has_many :maked_recipes, through: :makes, source: :recipe
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, length: { maximum: 255 }
+  validates :introduction, length: { maximum: 200 }
   validates :characteristic, presence: true
   # 法人または一般の属性を定義
   enum characteristic: {
@@ -19,6 +21,7 @@ class User < ApplicationRecord
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
       user.name = "ゲストユーザ"
+      user.characteristic = 1
     end
   end
 

--- a/app/uploaders/menu_image_uploader.rb
+++ b/app/uploaders/menu_image_uploader.rb
@@ -51,7 +51,8 @@ class MenuImageUploader < CarrierWave::Uploader::Base
 
   # 投稿画像のファイルサイズを指定
   def size_range
-    0..5.megabytes
+    num = (0..5)
+    num.megabytes
   end
 
   # ファイル名をランダムに変更

--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -50,7 +50,8 @@ class ProfileImageUploader < CarrierWave::Uploader::Base
 
   # 投稿画像のファイルサイズを指定
   def size_range
-    0..5.megabytes
+    num = (0..5)
+    num.megabytes
   end
 
   # ファイル名をランダムに変更

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,53 +1,71 @@
-<div class="devise-container w-2/5 m-auto mt-20">
-  <%= link_to t('devise.shared.links.back'), :back, class: 'back-link' %>
-  <h2>アカウント編集</h2>
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-
-    <div>
-      <div><%= image_tag current_user.profile_image.url %></div>
-      <p>プロフィール画像：<%= f.file_field :profile_image, accept: "image/png,image/jpeg,image/gif" %></p>
-    </div>
-    <%# お名前を更新するフォーム %>
-    <div class="field">
-      <%= f.label :name %><br />
-      <%= f.text_field :name %>
-    </div>
-
-    <div class="field">
-      <%= f.label :email %><br />
-      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-    </div>
-
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+<div class="devise-container pt-20 px-40">
+  <div class="px-12 m-auto">
+    <%= link_to :back, class: "back-link text-xl", data: { confirm: "入力したものは保存されませんがよろしいですか？" } do %>
+      <i class="fa-solid fa-angles-left"></i> キャンセル
     <% end %>
 
-    <div class="field">
-      <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
-      <%= f.password_field :password, autocomplete: "new-password" %>
-      <% if @minimum_password_length %>
-        <br />
-        <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
-      <% end %>
-    </div>
+    <div class="mt-10">
+      <h2>アカウント編集</h2>
+      <div>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="field">
-      <%= f.label :password_confirmation %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-    </div>
+          <div class="flex mt-10">
+            <div class="flex-1">
+              <div class="m-8"><%= image_tag current_user.profile_image.url %></div>
+              <p>プロフィール画像：<%= f.file_field :profile_image, accept: "image/png,image/jpeg,image/gif" %></p>
+            </div>
+            <%# 名前を更新するフォーム %>
+            <div class="flex-1">
+              <div class="field">
+                <%= f.label :name %> (50文字以内で入力してください)<br>
+                <%= f.text_field :name, autofocus: true %>
+              </div>
 
-    <div class="field">
-      <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
-      <%= f.password_field :current_password, autocomplete: "current-password" %>
-    </div>
+              <div class="field">
+                <%= f.label :email %><br />
+                <%= f.email_field :email, autocomplete: "email" %>
+              </div>
 
-    <div class="actions">
-      <%= f.submit t('.update') %>
-    </div>
-  <% end %>
+              <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+                <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
+              <% end %>
 
-  <div class="delete-wrapper">
-    <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete, class: 'delete-account' %>
+              <div class="field">
+                <%= f.label :password %> <i>(<%= t('.leave_blank_if_you_don_t_want_to_change_it') %>)</i><br />
+                <%= f.password_field :password, autocomplete: "new-password" %>
+                <% if @minimum_password_length %>
+                  <br />
+                  <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em>
+                <% end %>
+              </div>
+
+              <div class="field">
+                <%= f.label :password_confirmation %><br />
+                <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+              </div>
+
+              <div class="field">
+                <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
+                <%= f.password_field :current_password, autocomplete: "current-password" %>
+              </div>
+            </div>
+          </div>
+          
+          <div class="mt-10 justify-center">
+            <%= f.label :introduction %> (200文字以内で入力してください)<br>
+            <%= f.text_area :introduction, class: "texearea-box" %>
+          </div>
+
+          <div class="actions mt-10 text-center">
+            <%= f.submit t('.update') %>
+          </div>
+        <% end %>
+
+        <div class="delete-wrapper mt-10 text-center">
+          <%= button_to t('.cancel_my_account'), registration_path(resource_name), data: { confirm: t('.are_you_sure') }, method: :delete %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,10 +5,10 @@
     <% end %>
 
     <div class="mt-10">
+      <%= render "devise/shared/error_messages", resource: resource %>
       <h2>アカウント編集</h2>
       <div>
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-          <%= render "devise/shared/error_messages", resource: resource %>
 
           <div class="flex mt-10">
             <div class="flex-1">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,5 @@
 <div class="devise-container pt-20 px-40">
+  <%= render "devise/shared/error_messages", resource: resource %>
   <h2>Welcome!</h2>
   <p class="pl-8 pt-4">- <%= t('.sign_up') %> -</p>
 
@@ -10,7 +11,6 @@
 
     <div class="flex-1 px-4 mb-20">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
 
         <%# 法人または一般の属性を選択するフォーム %>
         <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,12 +23,12 @@
         <%# お名前を入力するフォーム %>
         <div class="field">
           <%= f.label :name %><br />
-          <%= f.text_field :name %>
+          <%= f.text_field :name, required: true, placeholder: "50文字以内で入力してください" %>
         </div>
 
         <div class="field">
           <%= f.label :email %><br />
-          <%= f.email_field :email %>
+          <%= f.email_field :email, required: true %>
         </div>
 
         <div class="field">

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,11 +1,12 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-    <h2>
+    <h3 class="mb-4 text-xl">
+      <i class="fa-solid fa-triangle-exclamation error"></i>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
-    </h2>
+    </h3>
     <ul>
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>


### PR DESCRIPTION
## 概要

- アカウント編集画面のスタイルを修正
- ゲストユーザの属性を法人に変更
- バリデーションを追加記述
- エラーメッセージのスタイルを修正

### 実装内容

- アカウント編集画面のイメージと入力フォームをフレックスで横並びにしスッキリさせた
- ゲストユーザにおすすめ機能を制限するためログインした際に法人で保存をかける
- `:name` `:email` `:introduction`にバリデーションを記述して空値と文字数制限をかける
- エラーメッセージの表示場所を変更し、見やすいように背景色を追加