### PR TITLE
add platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.22.0)
     parser (3.1.1.0)
@@ -340,6 +342,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
## 実装内容

- Capistranoでデプロイを実行後、`bundle lock --add-platform x86_64-linux`の指示があったため、実行
    - Gemfile.lockに`x86_64-linux`が追加されるコマンド
    - 実行後、Gemfile.lockに追加されていることを確認