### PR TITLE
modefied database

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,7 +50,7 @@ test:
 #
 production:
   <<: *default
-  database: funcoo_app_production
+  database: fun_coo_app_production
   username: root
   password: <%= Rails.application.credentials.db[:password] %>
   host: <%= Rails.application.credentials.db[:hostname] %>


### PR DESCRIPTION
## 実装内容

- Capistranoでデプロイ実施もdatabase名の違いによりエラーが発生
    - `database.yml`の`production`内の`database`を修正