### PR TITLE
modified puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,8 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT", 3000)
+# port ENV.fetch("PORT", 3000)
+bind "unix://#{Rails.root}/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
## 実装内容

- デプロイ後、アプリが表示されずログを見たところ`puma.sock`が生成されていないことがわかった
    - `config/puma.rb`内に`bind "unix://#{Rails.root}/tmp/sockets/puma.sock"`を追記