### PR TITLE
レベル機能の実装　Feature/level task 01

### DIFF
--- a/app/assets/stylesheets/devise.scss
+++ b/app/assets/stylesheets/devise.scss
@@ -41,7 +41,7 @@
   min-height: 100vh;
   background-color: #fbf6f0;
   .field {
-    margin-top: 2rem;
+    margin-top: 1rem;
   }
   input[type='text'] {
     @include input-layout;

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -89,10 +89,16 @@
   }
   // *-*-* 一覧ページのスタイル *-*-*
   .flex-left {
-    flex-basis: 25%;
+    flex-basis: 20%;
   }
   .flex-right {
-    flex-basis: 75%;
+    flex-basis: 60%;
+  }
+  .flex-right {
+    flex-basis: 20%;
+  }
+  .login-btn {
+    @include submit-btn;
   }
   // *-*-* 「作ってみた！」を促すコンテンツのスタイル *-*-*
   .makes-info-wrapper {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,13 +8,19 @@ class ApplicationController < ActionController::Base
                                         :name,
                                         :characteristic,
                                         :introduction,
-                                        :profile_image
+                                        :profile_image,
+                                        :level,
+                                        :experience_point,
+                                        :rest_point
                                       ])
     devise_parameter_sanitizer.permit(:account_update, keys: [
                                         :name,
                                         :characteristic,
                                         :introduction,
-                                        :profile_image
+                                        :profile_image,
+                                        :level,
+                                        :experience_point,
+                                        :rest_point
                                       ])
   end
 

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,15 +1,7 @@
 class MakesController < ApplicationController
   def create
     current_user.makes.create!(recipe_id: params[:recipe_id])
-    current_point = current_user.experience_point
-    adding_point = LevelSetting.calc_adding_point(current_user)
-    current_point += adding_point
-    current_user.update!(experience_point: current_point)
-    next_level = LevelSetting.find_by(passing_level: current_user.level + 1)
-    if next_level.threshold <= current_user.experience_point
-      current_user.level += 1
-      current_user.update!(level: current_user.level)
-    end
+    LevelSetting.calc_level(current_user)
     @recipe = Recipe.find(params[:recipe_id])
   end
 

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -1,6 +1,15 @@
 class MakesController < ApplicationController
   def create
     current_user.makes.create!(recipe_id: params[:recipe_id])
+    current_point = current_user.experience_point
+    adding_point = LevelSetting.calc_adding_point(current_user)
+    current_point += adding_point
+    current_user.update!(experience_point: current_point)
+    next_level = LevelSetting.find_by(passing_level: current_user.level + 1)
+    if next_level.threshold <= current_user.experience_point
+      current_user.level += 1
+      current_user.update!(level: current_user.level)
+    end
     @recipe = Recipe.find(params[:recipe_id])
   end
 

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -7,6 +7,7 @@ class MakesController < ApplicationController
 
   def destroy
     current_user.makes.find_by(recipe_id: params[:recipe_id]).destroy!
+    LevelSetting.down_level(current_user)
     @recipe = Recipe.find(params[:recipe_id])
   end
 end

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -1,0 +1,2 @@
+class LevelSetting < ApplicationRecord
+end

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -9,18 +9,13 @@ class LevelSetting < ApplicationRecord
 
     def down_level(user)
       current_point = user.experience_point
-      reducing_point = current_point * 0.2
-      reducing_point = reducing_point.round
-      current_point -= reducing_point
-      user.update!(experience_point: current_point)
-      current_level = LevelSetting.find_by(passing_level: user.level)
-      return unless current_level.present? && current_level.threshold >= current_point
-
-      user.level -= 1
-      user.update!(level: user.level)
+      reducing_point = calc_reducing_point(current_point)
+      reducing_current_point(user, current_point, reducing_point)
+      down_current_level(user)
     end
 
-    # *-*-* ここからprivateメソッド *-*-*
+    # *-*-* ここからclass_privateメソッド *-*-*
+    # *-*-* ここからcalc_levelメソッドの呼び出し先 *-*-*
     def calc_adding_point(user)
       adding_point = user.experience_point * 0.2
       adding_point.round
@@ -38,8 +33,30 @@ class LevelSetting < ApplicationRecord
       current_user.level += 1
       current_user.update!(level: current_user.level)
     end
+
+    # *-*-* ここからdown_levelメソッドの呼び出し先 *-*-*
+    def calc_reducing_point(current_point)
+      reducing_point = current_point * 0.2
+      reducing_point.round
+    end
+
+    def reducing_current_point(current_user, current_point, reducing_point)
+      current_point -= reducing_point
+      current_user.update!(experience_point: current_point)
+    end
+
+    def down_current_level(current_user)
+      current_level = LevelSetting.find_by(passing_level: current_user.level)
+      return unless current_level.present? && current_level.threshold >= current_user.experience_point
+
+      current_user.level -= 1
+      current_user.update!(level: current_user.level)
+    end
   end
   private_class_method :calc_adding_point,
                        :update_experience_point,
-                       :update_level
+                       :update_level,
+                       :calc_reducing_point,
+                       :reducing_current_point,
+                       :down_current_level
 end

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -1,10 +1,31 @@
 class LevelSetting < ApplicationRecord
-  def self.calc_adding_point(user)
-    adding_point = if user.experience_point.zero?
-                     15
-                   else
-                     user.experience_point * 0.2
-                   end
-    adding_point.round
+  class << self
+    def calc_level(user)
+      current_point = user.experience_point
+      adding_point = calc_adding_point(user)
+      update_experience_point(user, current_point, adding_point)
+      update_level(user)
+    end
+
+    def calc_adding_point(user)
+      adding_point = user.experience_point * 0.2
+      adding_point.round
+    end
+
+    def update_experience_point(current_user, current_point, adding_point)
+      current_point += adding_point
+      current_user.update!(experience_point: current_point)
+    end
+
+    def update_level(current_user)
+      next_level = LevelSetting.find_by(passing_level: current_user.level + 1)
+      return unless next_level.threshold <= current_user.experience_point
+
+      current_user.level += 1
+      current_user.update!(level: current_user.level)
+    end
   end
+  private_class_method :calc_adding_point,
+                       :update_experience_point,
+                       :update_level
 end

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -1,2 +1,10 @@
 class LevelSetting < ApplicationRecord
+  def self.calc_adding_point(user)
+    adding_point = if user.experience_point.zero?
+                     15
+                   else
+                     user.experience_point * 0.2
+                   end
+    adding_point.round
+  end
 end

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -19,7 +19,11 @@ class LevelSetting < ApplicationRecord
     # *-*-* ここからclass_privateメソッド *-*-*
     # *-*-* ここからcalc_levelメソッドの呼び出し先 *-*-*
     def calc_adding_point(user)
-      adding_point = user.experience_point * 0.2
+      adding_point = if user.experience_point.zero?
+                       15
+                     else
+                       user.experience_point * 0.2
+                     end
       adding_point.round
     end
 

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -7,6 +7,20 @@ class LevelSetting < ApplicationRecord
       update_level(user)
     end
 
+    def down_level(user)
+      current_point = user.experience_point
+      reducing_point = current_point * 0.2
+      reducing_point = reducing_point.round
+      current_point -= reducing_point
+      user.update!(experience_point: current_point)
+      current_level = LevelSetting.find_by(passing_level: user.level)
+      return unless current_level.present? && current_level.threshold >= current_point
+
+      user.level -= 1
+      user.update!(level: user.level)
+    end
+
+    # *-*-* ここからprivateメソッド *-*-*
     def calc_adding_point(user)
       adding_point = user.experience_point * 0.2
       adding_point.round

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -5,6 +5,9 @@ class LevelSetting < ApplicationRecord
       adding_point = calc_adding_point(user)
       update_experience_point(user, current_point, adding_point)
       update_level(user)
+      next_level = LevelSetting.find_by(passing_level: user.level + 1)
+      rest_point = next_level.threshold - user.experience_point
+      user.update!(rest_point:)
     end
 
     def down_level(user)
@@ -32,6 +35,7 @@ class LevelSetting < ApplicationRecord
 
       current_user.level += 1
       current_user.update!(level: current_user.level)
+      next_level
     end
 
     # *-*-* ここからdown_levelメソッドの呼び出し先 *-*-*

--- a/app/models/level_setting.rb
+++ b/app/models/level_setting.rb
@@ -5,9 +5,7 @@ class LevelSetting < ApplicationRecord
       adding_point = calc_adding_point(user)
       update_experience_point(user, current_point, adding_point)
       update_level(user)
-      next_level = LevelSetting.find_by(passing_level: user.level + 1)
-      rest_point = next_level.threshold - user.experience_point
-      user.update!(rest_point:)
+      calc_rest_point(user)
     end
 
     def down_level(user)
@@ -15,6 +13,7 @@ class LevelSetting < ApplicationRecord
       reducing_point = calc_reducing_point(current_point)
       reducing_current_point(user, current_point, reducing_point)
       down_current_level(user)
+      calc_rest_point(user)
     end
 
     # *-*-* ここからclass_privateメソッド *-*-*
@@ -30,7 +29,7 @@ class LevelSetting < ApplicationRecord
     end
 
     def update_level(current_user)
-      next_level = LevelSetting.find_by(passing_level: current_user.level + 1)
+      next_level = define_next_level(current_user)
       return unless next_level.threshold <= current_user.experience_point
 
       current_user.level += 1
@@ -56,11 +55,24 @@ class LevelSetting < ApplicationRecord
       current_user.level -= 1
       current_user.update!(level: current_user.level)
     end
+
+    # *-*-* ここからdown_level、calc_levelメソッド共通の呼び出し先 *-*-*
+    def calc_rest_point(user)
+      next_level = define_next_level(user)
+      rest_point = next_level.threshold - user.experience_point
+      user.update!(rest_point:)
+    end
+
+    def define_next_level(user)
+      LevelSetting.find_by(passing_level: user.level + 1)
+    end
   end
   private_class_method :calc_adding_point,
                        :update_experience_point,
                        :update_level,
                        :calc_reducing_point,
                        :reducing_current_point,
-                       :down_current_level
+                       :down_current_level,
+                       :define_next_level,
+                       :calc_rest_point
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,10 +3,15 @@ class User < ApplicationRecord
   has_many :makes, dependent: :destroy
   has_many :maked_recipes, through: :makes, source: :recipe
 
-  validates :name, presence: true, length: { maximum: 50 }
-  validates :email, presence: true, length: { maximum: 255 }
+  with_options presence: true do
+    validates :name, length: { maximum: 50 }
+    validates :email, length: { maximum: 255 }
+    validates :characteristic
+    validates :level
+    validates :experience_point
+    validates :rest_point
+  end
   validates :introduction, length: { maximum: 200 }
-  validates :characteristic, presence: true
   # 法人または一般の属性を定義
   enum characteristic: {
     general: 0,

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,6 +17,14 @@
             </div>
             <%# 名前を更新するフォーム %>
             <div class="flex-1">
+              <div class="pt-6">
+                <div class="flex">
+                  <p class="mr-8">現在の Lv. <%= current_user.level %></p>
+                  <p>経験値 <%= current_user.experience_point %>Exp</p>
+                </div>
+                <p>次のレベルまであと <%= current_user.rest_point %>Exp</p>
+              </div>
+
               <div class="field">
                 <%= f.label :name %> (50文字以内で入力してください)<br>
                 <%= f.text_field :name, autofocus: true %>

--- a/app/views/recipes/_make.html.erb
+++ b/app/views/recipes/_make.html.erb
@@ -1,5 +1,5 @@
 <%# 「作ってみた!」を押している状態 %>
-<%= link_to recipe_makes_path(recipe), method: :delete, remote: true do %>
+<%= link_to recipe_makes_path(recipe), method: :delete, data: { confirm: 'レベルが下がる可能性がありますが、実行しますか？'}, remote: true do %>
   <i class="fa-solid fa-thumbs-up text-primary"></i>
   <%= recipe.makes_count %>
 <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,10 +1,10 @@
 <div class="recipes-container">
-  <div class="flex">
-    <aside class="pt-24 pl-3 flex-left">
+  <div class="flex pt-24">
+    <aside class="pl-3 flex-left">
       <%= render "search_form", collection: @q %>
     </aside>
 
-    <div class="pt-24 flex-right">
+    <div class="flex-center">
       <div class="w-4/5 m-auto">
         <% if current_user.characteristic == "general" %>
           <section class="mb-10">
@@ -40,12 +40,32 @@
 
         <section>
           <h2>レシピ一覧</h2>
-          <div class="grid grid-cols-3 gap-4 my-10">
+          <div class="grid grid-cols-2 gap-4 my-10">
             <%= render @recipes %>
           </div>
         </section>
       </div>
     </div>
+
+    <aside class="pr-3 flex-right">
+      <% if user_signed_in? %>
+        <div>
+          <p><%= current_user.name %>さんの情報</p>
+          <p>現在の Lv. <%= current_user.level %></p>
+          <p>経験値 <%= current_user.experience_point %>Exp</p>
+          <p>次のレベルまであと <%= current_user.rest_point %>Exp</p>
+        </div>
+      <% else %>
+        <div>
+          <p>ユーザ情報</p>
+          <p>新規登録 or ログインをするとユーザ情報を表示します</p>
+          <%= link_to 'ログイン', new_user_session_path, class: 'login-btn' %>
+        </div>
+      <% end %>
+      <div class="mt-8">
+        <p>運営からのお知らせ</p>
+      </div>
+    </aside>
   </div>
   <div class="paginate"><%= paginate @recipes %></div>
 </div>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,8 +15,8 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT", 3000)
-# bind "unix:///var/www/fun_coo_app/shared/tmp/sockets/puma.sock"
+# port ENV.fetch("PORT", 3000)
+bind "unix:///var/www/fun_coo_app/shared/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,8 +15,8 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-# port ENV.fetch("PORT", 3000)
-bind "unix:///var/www/fun_coo_app/shared/tmp/sockets/puma.sock"
+port ENV.fetch("PORT", 3000)
+# bind "unix:///var/www/fun_coo_app/shared/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/db/migrate/20220424014559_add_level_colums_to_users.rb
+++ b/db/migrate/20220424014559_add_level_colums_to_users.rb
@@ -1,0 +1,7 @@
+class AddLevelColumsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :level, :integer, null: false, default: 1
+    add_column :users, :experience_point, :integer, null: false, default: 0
+    add_column :users, :rest_point, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20220424014559_add_level_colums_to_users.rb
+++ b/db/migrate/20220424014559_add_level_colums_to_users.rb
@@ -1,7 +1,7 @@
 class AddLevelColumsToUsers < ActiveRecord::Migration[6.1]
   def change
     add_column :users, :level, :integer, null: false, default: 1
-    add_column :users, :experience_point, :integer, null: false, default: 15
-    add_column :users, :rest_point, :integer, null: false, default: 0
+    add_column :users, :experience_point, :integer, null: false, default: 0
+    add_column :users, :rest_point, :integer, null: false, default: 30
   end
 end

--- a/db/migrate/20220424014559_add_level_colums_to_users.rb
+++ b/db/migrate/20220424014559_add_level_colums_to_users.rb
@@ -1,7 +1,7 @@
 class AddLevelColumsToUsers < ActiveRecord::Migration[6.1]
   def change
     add_column :users, :level, :integer, null: false, default: 1
-    add_column :users, :experience_point, :integer, null: false, default: 0
+    add_column :users, :experience_point, :integer, null: false, default: 15
     add_column :users, :rest_point, :integer, null: false, default: 0
   end
 end

--- a/db/migrate/20220424015932_create_level_settings.rb
+++ b/db/migrate/20220424015932_create_level_settings.rb
@@ -1,0 +1,10 @@
+class CreateLevelSettings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :level_settings do |t|
+      t.integer :passing_level
+      t.integer :threshold
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,8 +67,8 @@ ActiveRecord::Schema.define(version: 2022_04_24_015932) do
     t.text "introduction"
     t.string "profile_image"
     t.integer "level", default: 1, null: false
-    t.integer "experience_point", default: 15, null: false
-    t.integer "rest_point", default: 0, null: false
+    t.integer "experience_point", default: 0, null: false
+    t.integer "rest_point", default: 30, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_07_024547) do
+ActiveRecord::Schema.define(version: 2022_04_24_014559) do
 
   create_table "genres", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "recipe_id", null: false
@@ -59,6 +59,9 @@ ActiveRecord::Schema.define(version: 2022_04_07_024547) do
     t.string "name", null: false
     t.text "introduction"
     t.string "profile_image"
+    t.integer "level", default: 1, null: false
+    t.integer "experience_point", default: 0, null: false
+    t.integer "rest_point", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,7 +67,7 @@ ActiveRecord::Schema.define(version: 2022_04_24_015932) do
     t.text "introduction"
     t.string "profile_image"
     t.integer "level", default: 1, null: false
-    t.integer "experience_point", default: 0, null: false
+    t.integer "experience_point", default: 15, null: false
     t.integer "rest_point", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_24_014559) do
+ActiveRecord::Schema.define(version: 2022_04_24_015932) do
 
   create_table "genres", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "recipe_id", null: false
@@ -21,6 +21,13 @@ ActiveRecord::Schema.define(version: 2022_04_24_014559) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["recipe_id"], name: "index_genres_on_recipe_id"
+  end
+
+  create_table "level_settings", charset: "utf8mb4", force: :cascade do |t|
+    t.integer "passing_level"
+    t.integer "threshold"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "makes", charset: "utf8mb4", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,7 @@ ActiveRecord::Base.connection.execute("TRUNCATE TABLE users")
 ActiveRecord::Base.connection.execute("TRUNCATE TABLE recipes")
 ActiveRecord::Base.connection.execute("TRUNCATE TABLE makes")
 ActiveRecord::Base.connection.execute("TRUNCATE TABLE genres")
+ActiveRecord::Base.connection.execute("TRUNCATE TABLE level_settings")
 ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
 
 require "faker"
@@ -31,6 +32,15 @@ recipe_ids.each do |id|
   Make.create!(user_id: 3, recipe_id: id)
   Make.create!(user_id: 4, recipe_id: id)
   Make.create!(user_id: 5, recipe_id: id)
+end
+
+i = 2
+point = 30
+50.times do
+  LevelSetting.create!(passing_level: i, threshold: point)
+  i += 1
+  point *= 1.2
+  point = point.round
 end
 
 puts "初期データの挿入に成功しました！"

--- a/spec/factories/level_settings.rb
+++ b/spec/factories/level_settings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :level_setting do
+    passing_level { 1 }
+    threshold { 1 }
+  end
+end

--- a/spec/models/level_setting_spec.rb
+++ b/spec/models/level_setting_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe LevelSetting, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 実装内容

- `Users`テーブルに`level`、`experience_point`、`rest_point`カラムを追加
- `LevelSettings`テーブルを作成 => レベルとその閾値を格納するテーブル
- `level`、`experience_point`、`rest_point`カラムにデフォルト値を設定
- `db/seeds.rb`に初期値を入れる処理を記述
    - 初期段階ではレベル50まで格納
- 作ってみたを押してレベルを上げるための経験値操作する処理を記述
- 作ってみたを取り消した時のレベルを下げる処理を記述
- 次のレベルまでの残り経験値を計算する処理を記述
- レベル機能を一覧ページ右端とアカウント編集ページに表示