### PR TITLE
レコメンド機能の改善　Feature/recommend modification 02

### DIFF
--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -2,76 +2,7 @@ class MakesController < ApplicationController
   def create
     current_user.makes.create!(recipe_id: params[:recipe_id])
     LevelSetting.calc_level(current_user)
-
-    # 必要になる変数を取得しておく
-    maked_recipe = Genre.find_by(recipe_id: params[:recipe_id])
-    sum_makes = Make.where(user_id: current_user.id).count(:user_id)
-    recommend_columns = Recommend.find_or_create_by!(user_id: current_user.id)
-
-    # これまで選択したジャンル番号の合計を更新する処理
-    sum_staple = recommend_columns.sum_staple + maked_recipe.staple_food_before_type_cast
-    sum_main = recommend_columns.sum_main + maked_recipe.main_dish_before_type_cast
-    sum_side = recommend_columns.sum_side + maked_recipe.side_dish_before_type_cast
-    sum_country = recommend_columns.sum_country + maked_recipe.country_dish_before_type_cast
-
-    # 作ってみたを押した時に、これまで選択したジャンル番号の合計からsum_makesで割る => 平均ジャンル番号
-    avg_staple = sum_staple / sum_makes.to_f
-    avg_main = sum_main / sum_makes.to_f
-    avg_side = sum_side / sum_makes.to_f
-    avg_country = sum_country / sum_makes.to_f
-
-    # 作ってみたを押した投稿に同じく作ってみたを押した最新5人のユーザIDを抽出する
-    user_ids = Make.where(recipe_id: params[:recipe_id]).order(created_at: :desc).limit(5).offset(1).pluck(:user_id)
-    if user_ids.present?
-      # 一人一人の平均ジャンル(avg_staple...)を取得する
-      partners_avg_columns = []
-      user_ids.each do |user_id|
-        partners_avg_columns << Recommend.find_by(user_id:)
-      end
-
-      # ターゲットとなるログインユーザの平均ジャンル(avg_staple...)を格納する
-      target = [avg_staple, avg_main, avg_side, avg_country]
-      # 比較対象のパートナーとなるユーザの平均ジャンル(avg_staple...)を格納する
-      similarity_results = []
-      partners_avg_columns.each do |column|
-        partner = [column.avg_staple, column.avg_main, column.avg_side, column.avg_country]
-        calc_result = cosine_similarity(target, partner).round(3)
-        similarity_results << calc_result
-      end
-
-      # 格納した結果の中で最も1に近い値のインデックス番号を取得する
-      num = 1
-      result = similarity_results.min_by { |x| (x - num).abs }
-      # user_idsのインデックス番号と同じ要素を取り出してユーザIDを抽出する
-      index_num = similarity_results.find_index(result)
-
-      # user_idsのインデックス番号を指定してユーザIDを抽出する
-      friendly_user_id = user_ids[index_num]
-
-      # friendly_userが「作ってみた」を押したレシピIDを取得する
-      recommend_recipes = Make.where(user_id: friendly_user_id).order(created_at: :desc).limit(14).pluck(:recipe_id)
-      # recommend_recipesの中でログインユーザがまだ「作ってみた」を押していない最新のレシピIDを抽出する
-      # ログインユーザが作ってみたを押したレシピID(最新14件)を取得する
-      target_maked_recipes = Make.where(user_id: current_user.id).order(created_at: :desc).limit(14).pluck(:recipe_id)
-
-      # ログインユーザがまだ「作ってみた」を押していない最新のレシピIDを抽出する
-      recommend_recipe_id = recommend_recipes - target_maked_recipes
-
-      # recommend_recipe_idを最新のおすすめレシピIDとしてカラムに保存する
-      if recommend_recipe_id.present?
-        recommend_columns.update(recommend_recipe: recommend_recipe_id.last, avg_staple:, avg_main:, avg_side:, avg_country:
-        , sum_staple:, sum_main:, sum_side:, sum_country:)
-      else
-        substitute_for_recipe = Recipe.find_by(id: Genre.where(staple_food: avg_staple.round(0)).order(created_at: :desc).limit(1).pluck(:recipe_id))
-        recommend_columns.update(recommend_recipe: substitute_for_recipe.id, avg_staple:, avg_main:, avg_side:, avg_country:
-        , sum_staple:, sum_main:, sum_side:, sum_country:)
-      end
-    else
-      substitute_for_recipe = Recipe.find_by(id: Genre.where(staple_food: avg_staple.round(0)).order(created_at: :desc).limit(1).pluck(:recipe_id))
-      recommend_columns.update(recommend_recipe: substitute_for_recipe.id, avg_staple:, avg_main:, avg_side:, avg_country:
-      , sum_staple:, sum_main:, sum_side:, sum_country:)
-    end
-
+    Recommend.store_recipe_id(params[:recipe_id], current_user)
     @recipe = Recipe.find(params[:recipe_id])
   end
 
@@ -79,23 +10,5 @@ class MakesController < ApplicationController
     current_user.makes.find_by(recipe_id: params[:recipe_id]).destroy!
     LevelSetting.down_level(current_user)
     @recipe = Recipe.find(params[:recipe_id])
-  end
-
-  private
-
-  def cosine_similarity(target, partner)
-    dp = dot_product(target, partner)
-    nm = normalize(target) * normalize(partner)
-    dp / nm
-  end
-
-  def dot_product(target, partner)
-    sum = 0.0
-    target.each_with_index { |val, i| sum += val * partner[i] }
-    sum
-  end
-
-  def normalize(vector)
-    Math.sqrt(vector.inject(0.0) { |result, item| result + (item**2) })
   end
 end

--- a/app/controllers/makes_controller.rb
+++ b/app/controllers/makes_controller.rb
@@ -2,6 +2,76 @@ class MakesController < ApplicationController
   def create
     current_user.makes.create!(recipe_id: params[:recipe_id])
     LevelSetting.calc_level(current_user)
+
+    # 必要になる変数を取得しておく
+    maked_recipe = Genre.find_by(recipe_id: params[:recipe_id])
+    sum_makes = Make.where(user_id: current_user.id).count(:user_id)
+    recommend_columns = Recommend.find_or_create_by!(user_id: current_user.id)
+
+    # これまで選択したジャンル番号の合計を更新する処理
+    sum_staple = recommend_columns.sum_staple + maked_recipe.staple_food_before_type_cast
+    sum_main = recommend_columns.sum_main + maked_recipe.main_dish_before_type_cast
+    sum_side = recommend_columns.sum_side + maked_recipe.side_dish_before_type_cast
+    sum_country = recommend_columns.sum_country + maked_recipe.country_dish_before_type_cast
+
+    # 作ってみたを押した時に、これまで選択したジャンル番号の合計からsum_makesで割る => 平均ジャンル番号
+    avg_staple = sum_staple / sum_makes.to_f
+    avg_main = sum_main / sum_makes.to_f
+    avg_side = sum_side / sum_makes.to_f
+    avg_country = sum_country / sum_makes.to_f
+
+    # 作ってみたを押した投稿に同じく作ってみたを押した最新5人のユーザIDを抽出する
+    user_ids = Make.where(recipe_id: params[:recipe_id]).order(created_at: :desc).limit(5).offset(1).pluck(:user_id)
+    if user_ids.present?
+      # 一人一人の平均ジャンル(avg_staple...)を取得する
+      partners_avg_columns = []
+      user_ids.each do |user_id|
+        partners_avg_columns << Recommend.find_by(user_id:)
+      end
+
+      # ターゲットとなるログインユーザの平均ジャンル(avg_staple...)を格納する
+      target = [avg_staple, avg_main, avg_side, avg_country]
+      # 比較対象のパートナーとなるユーザの平均ジャンル(avg_staple...)を格納する
+      similarity_results = []
+      partners_avg_columns.each do |column|
+        partner = [column.avg_staple, column.avg_main, column.avg_side, column.avg_country]
+        calc_result = cosine_similarity(target, partner).round(3)
+        similarity_results << calc_result
+      end
+
+      # 格納した結果の中で最も1に近い値のインデックス番号を取得する
+      num = 1
+      result = similarity_results.min_by { |x| (x - num).abs }
+      # user_idsのインデックス番号と同じ要素を取り出してユーザIDを抽出する
+      index_num = similarity_results.find_index(result)
+
+      # user_idsのインデックス番号を指定してユーザIDを抽出する
+      friendly_user_id = user_ids[index_num]
+
+      # friendly_userが「作ってみた」を押したレシピIDを取得する
+      recommend_recipes = Make.where(user_id: friendly_user_id).order(created_at: :desc).limit(14).pluck(:recipe_id)
+      # recommend_recipesの中でログインユーザがまだ「作ってみた」を押していない最新のレシピIDを抽出する
+      # ログインユーザが作ってみたを押したレシピID(最新14件)を取得する
+      target_maked_recipes = Make.where(user_id: current_user.id).order(created_at: :desc).limit(14).pluck(:recipe_id)
+
+      # ログインユーザがまだ「作ってみた」を押していない最新のレシピIDを抽出する
+      recommend_recipe_id = recommend_recipes - target_maked_recipes
+
+      # recommend_recipe_idを最新のおすすめレシピIDとしてカラムに保存する
+      if recommend_recipe_id.present?
+        recommend_columns.update(recommend_recipe: recommend_recipe_id.last, avg_staple:, avg_main:, avg_side:, avg_country:
+        , sum_staple:, sum_main:, sum_side:, sum_country:)
+      else
+        substitute_for_recipe = Recipe.find_by(id: Genre.where(staple_food: avg_staple.round(0)).order(created_at: :desc).limit(1).pluck(:recipe_id))
+        recommend_columns.update(recommend_recipe: substitute_for_recipe.id, avg_staple:, avg_main:, avg_side:, avg_country:
+        , sum_staple:, sum_main:, sum_side:, sum_country:)
+      end
+    else
+      substitute_for_recipe = Recipe.find_by(id: Genre.where(staple_food: avg_staple.round(0)).order(created_at: :desc).limit(1).pluck(:recipe_id))
+      recommend_columns.update(recommend_recipe: substitute_for_recipe.id, avg_staple:, avg_main:, avg_side:, avg_country:
+      , sum_staple:, sum_main:, sum_side:, sum_country:)
+    end
+
     @recipe = Recipe.find(params[:recipe_id])
   end
 
@@ -9,5 +79,23 @@ class MakesController < ApplicationController
     current_user.makes.find_by(recipe_id: params[:recipe_id]).destroy!
     LevelSetting.down_level(current_user)
     @recipe = Recipe.find(params[:recipe_id])
+  end
+
+  private
+
+  def cosine_similarity(target, partner)
+    dp = dot_product(target, partner)
+    nm = normalize(target) * normalize(partner)
+    dp / nm
+  end
+
+  def dot_product(target, partner)
+    sum = 0.0
+    target.each_with_index { |val, i| sum += val * partner[i] }
+    sum
+  end
+
+  def normalize(vector)
+    Math.sqrt(vector.inject(0.0) { |result, item| result + (item**2) })
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,12 +1,15 @@
 class RecipesController < ApplicationController
   before_action :set_recipe, only: %i[edit update destroy]
+  before_action :take_recommend_recipe_id, only: :index
   before_action :authenticate_user!
 
   def index
     # PER_PAGEの参照先： ApplicationController
     @recipes = Recipe.includes(:user, :makes).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     # レコメンド機能の呼び出し
-    @recommend = Recipe.recommend(current_user) if current_user.characteristic == "general"
+    return unless current_user.characteristic == "general" || current_user.email == "guest@example.com"
+
+    @recommend = Recipe.find_by(id: @recommend_recipe_id)
   end
 
   def new
@@ -61,5 +64,9 @@ class RecipesController < ApplicationController
   def set_recipe
     @recipe = current_user.recipes.find_by(id: params[:id])
     redirect_to recipes_path, alert: "権限がありません" if @recipe.nil?
+  end
+
+  def take_recommend_recipe_id
+    @recommend_recipe_id = Recommend.where(user_id: current_user.id).pluck(:recommend_recipe)
   end
 end

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -1,4 +1,14 @@
 class Recommend < ApplicationRecord
   belongs_to :user
-  validates :recommend_recipe, :avg_staple, :avg_main, :avg_side, :avg_country, presence: true
+  with_options presence: true do
+    validates :recommend_recipe
+    validates :avg_staple
+    validates :avg_main
+    validates :avg_side
+    validates :avg_country
+    validates :sum_staple
+    validates :sum_main
+    validates :sum_side
+    validates :sum_country
+  end
 end

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -1,3 +1,4 @@
 class Recommend < ApplicationRecord
   belongs_to :user
+  validates :recommend_recipe, :avg_staple, :avg_main, :avg_side, :avg_country, presence: true
 end

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -1,0 +1,3 @@
+class Recommend < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/recommend.rb
+++ b/app/models/recommend.rb
@@ -1,14 +1,127 @@
 class Recommend < ApplicationRecord
   belongs_to :user
-  with_options presence: true do
-    validates :recommend_recipe
-    validates :avg_staple
-    validates :avg_main
-    validates :avg_side
-    validates :avg_country
-    validates :sum_staple
-    validates :sum_main
-    validates :sum_side
-    validates :sum_country
+  # クラス内Lineが長くなりすぎるため、with_optionsは使わずに対応(NOTNULL制約のバリデーション)
+  validates :recommend_recipe, :avg_staple, :avg_main, :avg_side, :avg_country,
+            :sum_staple, :sum_main, :sum_side, :sum_country, presence: true
+
+  class << self
+    def store_recipe_id(recipe_id, current_user)
+      maked_recipe, sum_makes, recommend_columns = set_variable(recipe_id, current_user)
+      sum_columns = calc_recommend_sum_columns(maked_recipe, recommend_columns)
+      avg_columns = calc_recommend_average_columns(sum_makes, sum_columns)
+
+      # 作ってみたを押した投稿に同じく作ってみたを押した最新5人のユーザIDを抽出する
+      user_ids = Make.where(recipe_id:).order(created_at: :desc).limit(5).offset(1).pluck(:user_id)
+      if user_ids.present?
+        # ターゲットとなるログインユーザの平均ジャンル(avg_staple...)を実引数として渡す
+        similarity_results = calc_cosine_similarity(user_ids, avg_columns)
+        recommend_recipe_id = select_recommend_recipe(user_ids, similarity_results, current_user)
+        update_recommend_recipe(recommend_recipe_id, recommend_columns, avg_columns, sum_columns)
+      else
+        substitute_for_recipe = substitute_for_recipe(avg_columns)
+        update_recommend_columns(recommend_columns, substitute_for_recipe.id, avg_columns, sum_columns)
+      end
+    end
+
+    # ====== ここからprivateクラスメソッド ======
+
+    # 必要になる変数を取得する処理
+    def set_variable(recipe_id, current_user)
+      maked_recipe = Genre.find_by(recipe_id:)
+      sum_makes = Make.where(user_id: current_user.id).count(:user_id)
+      recommend_columns = Recommend.find_or_create_by!(user_id: current_user.id)
+      [maked_recipe, sum_makes, recommend_columns]
+    end
+
+    # これまで選択したジャンル番号の合計を計算する処理
+    def calc_recommend_sum_columns(maked_recipe, recommend_columns)
+      sum_staple = recommend_columns.sum_staple + maked_recipe.staple_food_before_type_cast
+      sum_main = recommend_columns.sum_main + maked_recipe.main_dish_before_type_cast
+      sum_side = recommend_columns.sum_side + maked_recipe.side_dish_before_type_cast
+      sum_country = recommend_columns.sum_country + maked_recipe.country_dish_before_type_cast
+      [sum_staple, sum_main, sum_side, sum_country]
+    end
+
+    # 作ってみたを押した時に、これまで選択したジャンル番号の合計からsum_makesで割る処理 => 平均ジャンル番号を計算する
+    def calc_recommend_average_columns(sum_makes, sum_columns)
+      avg_staple = sum_columns[0] / sum_makes.to_f
+      avg_main = sum_columns[1] / sum_makes.to_f
+      avg_side = sum_columns[2] / sum_makes.to_f
+      avg_country = sum_columns[3] / sum_makes.to_f
+      [avg_staple, avg_main, avg_side, avg_country]
+    end
+
+    def calc_cosine_similarity(user_ids, target)
+      # 一人一人の平均ジャンル(avg_staple...)を取得する
+      partners_avg_columns = []
+      user_ids.each do |user_id|
+        partners_avg_columns << Recommend.find_by(user_id:)
+      end
+
+      # 比較対象のパートナーとなるユーザの平均ジャンル(avg_staple...)を格納する
+      similarity_results = []
+      partners_avg_columns.each do |column|
+        partner = [column.avg_staple, column.avg_main, column.avg_side, column.avg_country]
+        calc_result = cosine_similarity(target, partner).round(3)
+        similarity_results << calc_result
+      end
+      similarity_results
+    end
+
+    def select_recommend_recipe(user_ids, similarity_results, current_user)
+      # 格納した結果の中で最も1に近い値のインデックス番号を取得する
+      num = 1
+      result = similarity_results.min_by { |x| (x - num).abs }
+      # user_idsのインデックス番号と同じ要素を取り出してユーザIDを抽出する
+      index_num = similarity_results.find_index(result)
+      # user_idsのインデックス番号を指定してユーザIDを抽出する
+      friendly_user_id = user_ids[index_num]
+      # friendly_userが「作ってみた」を押したレシピIDを取得する
+      recommend_recipes = Make.where(user_id: friendly_user_id).order(created_at: :desc).limit(14).pluck(:recipe_id)
+      # ログインユーザが作ってみたを押したレシピID(最新14件)を取得する
+      target_maked_recipes = Make.where(user_id: current_user.id).order(created_at: :desc).limit(14).pluck(:recipe_id)
+      # ログインユーザがまだ「作ってみた」を押していない最新のレシピIDを抽出する
+      recommend_recipes - target_maked_recipes
+    end
+
+    def update_recommend_recipe(recommend_recipe_id, recommend_columns, avg_columns, sum_columns)
+      # recommend_recipe_idを最新のおすすめレシピIDとしてカラムに保存する
+      if recommend_recipe_id.present?
+        update_recommend_columns(recommend_columns, recommend_recipe_id.last, avg_columns, sum_columns)
+      else
+        substitute_for_recipe = substitute_for_recipe(avg_columns)
+        update_recommend_columns(recommend_columns, substitute_for_recipe.id, avg_columns, sum_columns)
+      end
+    end
+
+    def substitute_for_recipe(avg_columns)
+      recipe_id = Genre.where(staple_food: avg_columns[0].round(0)).order(created_at: :desc).limit(1).pluck(:recipe_id)
+      Recipe.find_by(id: recipe_id)
+    end
+
+    def update_recommend_columns(recommend_columns, recommend_recipe, avg_columns, sum_columns)
+      recommend_columns.update(recommend_recipe:, avg_staple: avg_columns[0], avg_main: avg_columns[1], avg_side: avg_columns[2],
+                               avg_country: avg_columns[3], sum_staple: sum_columns[0], sum_main: sum_columns[1],
+                               sum_side: sum_columns[2], sum_country: sum_columns[3])
+    end
+
+    def cosine_similarity(target, partner)
+      dp = dot_product(target, partner)
+      nm = normalize(target) * normalize(partner)
+      dp / nm
+    end
+
+    def dot_product(target, partner)
+      sum = 0.0
+      target.each_with_index { |val, i| sum += val * partner[i] }
+      sum
+    end
+
+    def normalize(vector)
+      Math.sqrt(vector.inject(0.0) { |result, item| result + (item**2) })
+    end
   end
+  private_class_method :set_variable, :calc_recommend_sum_columns, :calc_recommend_sum_columns,
+                       :calc_cosine_similarity, :cosine_similarity, :dot_product, :normalize,
+                       :select_recommend_recipe, :update_recommend_recipe, :substitute_for_recipe, :update_recommend_columns
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :makes, dependent: :destroy
   has_many :maked_recipes, through: :makes, source: :recipe
   has_many :sns_credential, dependent: :destroy
+  has_one :recommend, dependent: :destroy
 
   with_options presence: true do
     validates :name, length: { maximum: 50 }

--- a/db/migrate/20220506001834_create_recommends.rb
+++ b/db/migrate/20220506001834_create_recommends.rb
@@ -2,7 +2,7 @@ class CreateRecommends < ActiveRecord::Migration[6.1]
   def change
     create_table :recommends do |t|
       t.references :user, null: false, foreign_key: true
-      t.integer :recommend_recipe, null: false
+      t.integer :recommend_recipe, null: false, default: 0
       t.float :avg_staple, null: false, default: 0
       t.float :avg_main, null: false, default: 0
       t.float :avg_side, null: false, default: 0

--- a/db/migrate/20220506001834_create_recommends.rb
+++ b/db/migrate/20220506001834_create_recommends.rb
@@ -1,0 +1,14 @@
+class CreateRecommends < ActiveRecord::Migration[6.1]
+  def change
+    create_table :recommends do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :recommend_recipe, null: false
+      t.float :avg_staple, null: false, default: 0
+      t.float :avg_main, null: false, default: 0
+      t.float :avg_side, null: false, default: 0
+      t.float :avg_country, null: false, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220506001834_create_recommends.rb
+++ b/db/migrate/20220506001834_create_recommends.rb
@@ -7,6 +7,10 @@ class CreateRecommends < ActiveRecord::Migration[6.1]
       t.float :avg_main, null: false, default: 0
       t.float :avg_side, null: false, default: 0
       t.float :avg_country, null: false, default: 0
+      t.integer :sum_staple, null: false, default: 0
+      t.integer :sum_main, null: false, default: 0
+      t.integer :sum_side, null: false, default: 0
+      t.integer :sum_country, null: false, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 2022_05_06_001834) do
 
   create_table "recommends", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "recommend_recipe", null: false
+    t.integer "recommend_recipe", default: 0, null: false
     t.float "avg_staple", default: 0.0, null: false
     t.float "avg_main", default: 0.0, null: false
     t.float "avg_side", default: 0.0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_28_060200) do
+ActiveRecord::Schema.define(version: 2022_05_06_001834) do
 
   create_table "genres", charset: "utf8mb4", force: :cascade do |t|
     t.bigint "recipe_id", null: false
@@ -54,6 +54,18 @@ ActiveRecord::Schema.define(version: 2022_04_28_060200) do
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 
+  create_table "recommends", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "recommend_recipe", null: false
+    t.float "avg_staple", default: 0.0, null: false
+    t.float "avg_main", default: 0.0, null: false
+    t.float "avg_side", default: 0.0, null: false
+    t.float "avg_country", default: 0.0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_recommends_on_user_id"
+  end
+
   create_table "sns_credentials", charset: "utf8mb4", force: :cascade do |t|
     t.string "provider"
     t.string "uid"
@@ -87,5 +99,6 @@ ActiveRecord::Schema.define(version: 2022_04_28_060200) do
   add_foreign_key "makes", "recipes"
   add_foreign_key "makes", "users"
   add_foreign_key "recipes", "users"
+  add_foreign_key "recommends", "users"
   add_foreign_key "sns_credentials", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,6 +61,10 @@ ActiveRecord::Schema.define(version: 2022_05_06_001834) do
     t.float "avg_main", default: 0.0, null: false
     t.float "avg_side", default: 0.0, null: false
     t.float "avg_country", default: 0.0, null: false
+    t.integer "sum_staple", default: 0, null: false
+    t.integer "sum_main", default: 0, null: false
+    t.integer "sum_side", default: 0, null: false
+    t.integer "sum_country", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_recommends_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,39 +1,4 @@
-# テーブルを再生成
-ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 0")
-ActiveRecord::Base.connection.execute("TRUNCATE TABLE users")
-ActiveRecord::Base.connection.execute("TRUNCATE TABLE recipes")
-ActiveRecord::Base.connection.execute("TRUNCATE TABLE makes")
-ActiveRecord::Base.connection.execute("TRUNCATE TABLE genres")
-ActiveRecord::Base.connection.execute("TRUNCATE TABLE level_settings")
-ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
-
-require "faker"
-Faker::Config.locale = :ja
-
-# 開発用のユーザを作成
-user1 = User.create!(name: "sato", email: "sato@example.com", password: "password", characteristic: 1)
-user2 = User.create!(name: "hanada", email: "hanada@example.com", password: "password", characteristic: 1)
-
-5.times do
-  User.create!(name: Faker::Name.name, email: Faker::Internet.email, password: "password", characteristic: 0)
-end
-
-genre_num = (0..3).to_a
-30.times do
-  recipe_a = user1.recipes.create!(title: Faker::Food.dish, content: Faker::Food.description, cooking_time: 200, cooking_cost: 200, calorie: 200)
-  Genre.create(recipe_id: recipe_a.id, staple_food: genre_num.sample, main_dish: genre_num.sample, side_dish: genre_num.sample, country_dish: genre_num.sample)
-
-  recipe_b = user2.recipes.create!(title: Faker::Food.dish, content: Faker::Food.description, cooking_time: 200, cooking_cost: 200, calorie: 200)
-  Genre.create(recipe_id: recipe_b.id, staple_food: genre_num.sample, main_dish: genre_num.sample, side_dish: genre_num.sample, country_dish: genre_num.sample)
-end
-
-recipe_ids = (1..50).to_a
-recipe_ids.each do |id|
-  Make.create!(user_id: 3, recipe_id: id)
-  Make.create!(user_id: 4, recipe_id: id)
-  Make.create!(user_id: 5, recipe_id: id)
-end
-
+# ====== 本番環境のレベル閾値投入処理 ======
 i = 2
 point = 30
 50.times do
@@ -44,3 +9,42 @@ point = 30
 end
 
 puts "初期データの挿入に成功しました！"
+
+# ====== 開発環境の初期データ投入処理 ======
+
+# テーブルを再生成
+# ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 0")
+# table_names = ["users", "recipes", "makes", "genres", "level_settings", "recommends"]
+# table_names.each do |table_name|
+#   ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
+# end
+# ActiveRecord::Base.connection.execute("SET FOREIGN_KEY_CHECKS = 1")
+
+# require "faker"
+# Faker::Config.locale = :ja
+
+# # 開発用のユーザを作成
+# user1 = User.create!(name: "sato", email: "sato@example.com", password: "password", characteristic: 1)
+# user2 = User.create!(name: "hanada", email: "hanada@example.com", password: "password", characteristic: 1)
+
+# 5.times do
+#   User.create!(name: Faker::Name.name, email: Faker::Internet.email, password: "password", characteristic: 0)
+# end
+
+# genre_num = (0..3).to_a
+# 30.times do
+#   recipe_a = user1.recipes.create!(title: Faker::Food.dish, content: Faker::Food.description, cooking_time: 200, cooking_cost: 200, calorie: 200)
+#   Genre.create(recipe_id: recipe_a.id, staple_food: genre_num.sample, main_dish: genre_num.sample,
+#     side_dish: genre_num.sample, country_dish: genre_num.sample)
+
+#   recipe_b = user2.recipes.create!(title: Faker::Food.dish, content: Faker::Food.description, cooking_time: 200, cooking_cost: 200, calorie: 200)
+#   Genre.create(recipe_id: recipe_b.id, staple_food: genre_num.sample, main_dish: genre_num.sample,
+#     side_dish: genre_num.sample, country_dish: genre_num.sample)
+# end
+
+# recipe_ids = (1..50).to_a
+# recipe_ids.each do |id|
+#   Make.create!(user_id: 3, recipe_id: id)
+#   Make.create!(user_id: 4, recipe_id: id)
+#   Make.create!(user_id: 5, recipe_id: id)
+# end

--- a/spec/factories/recommends.rb
+++ b/spec/factories/recommends.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :recommend do
+    user { nil }
+    recommend_recipe { 1 }
+    avg_staple { 1.5 }
+    avg_main { 1.5 }
+    avg_side { 1.5 }
+    avg_country { 1.5 }
+  end
+end

--- a/spec/models/recommend_spec.rb
+++ b/spec/models/recommend_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Recommend, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 実装内容

- 計算処理の省略を行うため、Recommendモデルの作成
    - カラムは各ジャンルに対する`avg`と`sum`をprefixとした
- バリデーションとアソシエーションの設定
    - `NOTNULL`制約
- 「作ってみた！」を押した時にレコメンドするレシピIDを保存する処理を記述
    - 処理内容は`recommend.rb`に記述
- `recipes/index.html.erb`に表示するため`index`アクションを修正