### PR TITLE
スマートフォン用のフラッシュスタイルを修正

### DIFF
--- a/app/assets/stylesheets/layouts/flash.scss
+++ b/app/assets/stylesheets/layouts/flash.scss
@@ -41,7 +41,9 @@
   text-align: center;
   border-radius: 15px;
   @include sp {
-    left: 39px;
+    width: 100%;
+    left: 0px;
+    border-radius: 0px;
   }
   @include tb {
     left: 82px;


### PR DESCRIPTION
## 実装内容

- スマートフォン用のフラッシュを以下のように修正

```
width: 100%;
left: 0px
border-radius: 0px;
```