### PR TITLE
レシピ関連の修正　Feature/recipe modification 03

### DIFF
--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -71,6 +71,9 @@
     @include sp-tb {
       flex-basis: auto;
     }
+    @include sp {
+      padding: 0 0 30px 0;
+    }
     .top-heading {
       color: #5eaf23;
       font-size: 5em;
@@ -116,7 +119,14 @@
       }
       @include sp {
         flex-direction: column;
-        padding: 0 0 30px 0;
+      }
+    }
+    .visit-recipesLink {
+      color: #e8e8e8;
+      text-align: center;
+      margin-top: 8px;
+      &:hover {
+        color: #fbf6f0;
       }
     }
   }

--- a/app/assets/stylesheets/layouts/header.scss
+++ b/app/assets/stylesheets/layouts/header.scss
@@ -14,7 +14,7 @@
   }
 }
 @mixin nav-parts {
-  z-index: 2;
+  z-index: 10;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.6s;
@@ -24,7 +24,15 @@
   pointer-events: auto;
 }
 
-// *-*-* ヘッダーのレイアウト *-*-*
+header {
+  @include sp {
+    width: 100%;
+    position: fixed;
+    z-index: 2;
+  }
+}
+
+// ===== ヘッダーのレイアウト =====
 .header-wrapper {
   // text-align: center;
   background-color: rgba($color: #ffa45b, $alpha: 0.8);
@@ -89,7 +97,7 @@
   }
 }
 
-// *-*-* タブレット/PC用のナビ *-*-*
+// ===== タブレット/PC用のナビ =====
 .md-navWrapper {
   background-color: #fbf6f0;
   position: absolute;
@@ -116,7 +124,7 @@
   }
 }
 
-// *-*-* スマートフォン用のナビ *-*-*
+// ===== スマートフォン用のナビ =====
 .overlay {
   position: fixed;
   top: 0;

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -2,6 +2,22 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
 
+@mixin tb {
+  @media screen and (min-width: 790px) and (max-width: 1030px) {
+    @content;
+  }
+}
+@mixin sp {
+  @media screen and (max-width: 790px) {
+    @content;
+  }
+}
+@mixin sp-tb {
+  @media screen and (max-width: 1030px) {
+    @content;
+  }
+}
+
 // ===== 検索ボタン =====
 @mixin submit-btn {
   min-width: 130px;
@@ -26,27 +42,18 @@
   }
 }
 
-@mixin tb {
-  @media screen and (min-width: 790px) and (max-width: 1030px) {
-    @content;
-  }
-}
-@mixin sp {
-  @media screen and (max-width: 790px) {
-    @content;
-  }
-}
-@mixin sp-tb {
-  @media screen and (max-width: 1030px) {
-    @content;
-  }
-}
-
 // ===== 料理イメージの共通スタイル =====
 @mixin menu-image($height, $width) {
   border-radius: 15px;
   height: $height;
   width: $width;
+}
+
+// ===== よく使うflexのスタイル =====
+@mixin flex-style($content, $items) {
+  display: flex;
+  justify-content: $content;
+  align-items: $items;
 }
 
 .recipes-container {
@@ -130,9 +137,8 @@
     flex-basis: 60%;
     @include sp-tb {
       .recipeIndex-wrapper {
-        display: flex;
         flex-direction: column;
-        align-items: center;
+        @include flex-style(normal, center);
         .recommend-title {
           @include sp {
             text-align: center;
@@ -144,8 +150,7 @@
   .flex-right {
     flex-basis: 20%;
     @include tb {
-      display: flex;
-      justify-content: center;
+      @include flex-style(center, normal);
     }
     @include sp-tb {
       order: 2;
@@ -183,15 +188,12 @@
       flex-direction: column;
     }
     .make-wrapper {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+      @include flex-style(space-between, center);
       margin-top: auto;
     }
   }
   .cooking-info {
-    display: flex;
-    justify-content: right;
+    @include flex-style(right, normal);
     p {
       font-size: 14px;
       color: #aaa;
@@ -217,6 +219,18 @@
     @include sp {
       display: inherit;
     }
+    .sp-contributorInfo {
+      display: none;
+      @include sp {
+        display: flex;
+      }
+    }
+    .contributor-cooking {
+      @include flex-style(space-between, center);
+      @include sp {
+        @include flex-style(right, center);
+      }
+    }
     .recommed-img {
       @include menu-image(220, 330);
     }
@@ -226,9 +240,7 @@
     background: rgba($color: #aee6e6, $alpha: 0.8);
     border: #344963 solid 2px;
     border-radius: 10px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    @include flex-style(center, center);
     box-shadow: 2px 5px 12px 1px #d5d5d5;
   }
   // ===== 検索結果ページのスタイル =====
@@ -322,8 +334,7 @@
       margin: 0 auto;
     }
     .recipiSub_info {
-      display: flex;
-      justify-content: space-around;
+      @include flex-style(space-around, normal);
       margin: 0 auto;
       width: 964px;
       @include sp-tb {
@@ -352,8 +363,7 @@
   }
   .q-SearchBox {
     @include tb {
-      display: flex;
-      justify-content: space-around;
+      @include flex-style(space-around, normal);
     }
     .search-common {
       padding: 10px;

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -187,9 +187,12 @@
       display: flex;
       flex-direction: column;
     }
-    .make-wrapper {
-      @include flex-style(space-between, center);
-      margin-top: auto;
+  }
+  .make-wrapper {
+    @include flex-style(space-between, center);
+    margin-top: auto;
+    .index-rec-makeBtn {
+      margin-right: 16px;
     }
   }
   .cooking-info {
@@ -309,6 +312,9 @@
     @include sp-tb {
       display: none;
     }
+    .show-makeBtn {
+      margin-bottom: 16px;
+    }
   }
   .recipe-card {
     margin: 16px 0 100px;
@@ -318,6 +324,7 @@
       display: none;
       @include sp-tb {
         display: inherit;
+        margin: 0px 8px;
       }
     }
     .recipe-editIcon {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :search
   PER_PAGE = 20

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,3 +1,4 @@
 class HomesController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index]
   def index; end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -6,9 +6,7 @@ class RecipesController < ApplicationController
   def index
     # PER_PAGEの参照先： ApplicationController
     @recipes = Recipe.includes(:user, :makes, :favorites).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
-    return unless current_user.characteristic == "general" || current_user.email == "guest@example.com"
-
-    @recommend = Recipe.find_by(id: @recommend_recipe_id)
+    @recommend = Recipe.recommend_recipe(@recommend_recipe_id, current_user)
     @contributor = User.find_by(id: @recommend.user_id)
   end
 

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -1,11 +1,13 @@
 class RecipesController < ApplicationController
+  skip_before_action :authenticate_user!, only: %i[index]
   before_action :set_recipe, only: %i[edit update destroy]
-  before_action :take_recommend_recipe_id, only: :index
-  before_action :authenticate_user!
+  before_action :take_recommend_recipe_id, only: :index, if: :user_signed_in?
 
   def index
     # PER_PAGEの参照先： ApplicationController
     @recipes = Recipe.includes(:user, :makes, :favorites).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    return unless user_signed_in?
+
     @recommend = Recipe.recommend_recipe(@recommend_recipe_id, current_user)
     @contributor = User.find_by(id: @recommend.user_id) if @recommend.present?
   end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,7 +7,7 @@ class RecipesController < ApplicationController
     # PER_PAGEの参照先： ApplicationController
     @recipes = Recipe.includes(:user, :makes, :favorites).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     @recommend = Recipe.recommend_recipe(@recommend_recipe_id, current_user)
-    @contributor = User.find_by(id: @recommend.user_id)
+    @contributor = User.find_by(id: @recommend.user_id) if @recommend.present?
   end
 
   def new

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -26,32 +26,13 @@ class Recipe < ApplicationRecord
   end
 
   class << self
-    # レコメンド機能
-    def recommend(user)
-      # ログインユーザが「作ってみた！」を押した全ての投稿を新着順に取得
-      base_recipes = Make.where(user_id: user.id).order(created_at: :desc)
-      # その投稿の中で5番目のものを取得
-      base_recipe = base_recipes[4]
-      return nil if base_recipe.nil?
-
-      other = Recipe.take_user(base_recipe)
-      Recipe.take_recipe(other)
-    end
-
-    def take_user(base_recipe)
-      # その投稿に「作ってみた！」を押した全ての他ユーザを取得
-      others = Make.where(recipe_id: base_recipe.recipe_id).order(created_at: :desc)
-      # その投稿の中で最後に押した他ユーザを返す
-      others.first
-    end
-
-    def take_recipe(other)
-      # そのユーザが「作ってみた！」を押した全ての投稿を取得
-      other_maked_recipes = Make.where(user_id: other.user_id).order(created_at: :desc)
-      # その投稿の中で最新の投稿を取得する
-      other_maked_recipe = other_maked_recipes.first
-      # レシピクラスで投稿を取得する
-      Recipe.find_by(id: other_maked_recipe.recipe_id)
+    # ===== レコメンドレシピを渡す処理 =====
+    def recommend_recipe(recommend_recipe_id, current_user)
+      if current_user.characteristic == "general"
+        Recipe.find_by(id: recommend_recipe_id)
+      elsif current_user.email == "guest@example.com"
+        Recipe.find_by(id: Recipe.order(created_at: :desc).limit(1).pluck(:id))
+      end
     end
   end
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -24,6 +24,12 @@
         <%= link_to 'ゲストログイン(閲覧用)', users_guest_sign_in_path, method: :post, class: 'login-btn-guest' %>
       </div>
     </div>
+
+    <div class="visit-recipesLink">
+      <%= link_to recipes_path do %>
+        <i class="fa-solid fa-caret-right"></i> 一覧ページを覗いてみる
+      <% end %>
+    </div>
   </div>
 
   <div class="top-right"><%= image_tag "top-bg-img.jpg", class: "top-img", alt: "トップ画像" %></div>

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -28,23 +28,8 @@
     <div class="make-wrapper">
       <% if current_user.id != recipe.user_id %>
         <div class="flex">
-          <p id="recipe-<%= recipe.id %>" class="make-icon mr-4">
-            <% if recipe.maked_by?(current_user) %>
-              <%# 「作ってみた!」を押している状態 %>
-              <%= render "makes/make", recipe: recipe %>
-            <% else %>
-              <%# 「作ってみた!」を押していない状態 %>
-              <%= render "makes/nonmake", recipe: recipe %>
-            <% end %>
-          </p>
-          <%# ===== お気に入り機能 ===== %>
-          <p id="favorite-<%= recipe.id %>" class="make-icon favorite-btn">
-            <% if recipe.favorited_by?(current_user) %>
-              <%= render "favorites/favorite", recipe: recipe %>
-            <% else %>
-              <%= render "favorites/nonfavorite", recipe: recipe %>
-            <% end %>
-          </p>
+          <%# =====「作ってみた！」とお気に入りの部分テンプレート ===== %>
+          <%= render "recipes/shared/makes_favorites", recipe: recipe %>
         </div>
       <% end %>
 

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -25,28 +25,30 @@
       <%= truncate(recipe.content, omision: "...", length: 100) %>
     </div>
 
-    <div class="make-wrapper">
-      <% if current_user.id != recipe.user_id %>
-        <div class="flex">
-          <%# =====「作ってみた！」とお気に入りの部分テンプレート ===== %>
-          <%= render "recipes/shared/makes_favorites", recipe: recipe %>
-        </div>
-      <% end %>
+    <% if user_signed_in? %>
+      <div class="make-wrapper">
+        <% if current_user.id != recipe.user_id %>
+          <div class="flex">
+            <%# =====「作ってみた！」とお気に入りの部分テンプレート ===== %>
+            <%= render "recipes/shared/makes_favorites", recipe: recipe %>
+          </div>
+        <% end %>
 
-      <%= link_to recipe, class: "text-base hover:text-quaternary" do %>
-        <i class="fa-solid fa-caret-right"></i>  詳しく見る
-      <% end %>
+        <%= link_to recipe, class: "text-base hover:text-quaternary" do %>
+          <i class="fa-solid fa-caret-right"></i>  詳しく見る
+        <% end %>
 
-      <% if current_user.id == recipe.user_id %>
-        <div class="flex">
-          <%= link_to edit_recipe_path(recipe) do %>
-            <i class="fa-solid fa-pen-to-square recipe-edit"></i>
-          <% end %>
-          <%= link_to recipe_path(recipe), method: :delete, data: { confirm: '削除してもよろしいですか？'} do %>
-            <i class="fa-solid fa-trash-can recipe-delete"></i>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
+        <% if current_user.id == recipe.user_id %>
+          <div class="flex">
+            <%= link_to edit_recipe_path(recipe) do %>
+              <i class="fa-solid fa-pen-to-square recipe-edit"></i>
+            <% end %>
+            <%= link_to recipe_path(recipe), method: :delete, data: { confirm: '削除してもよろしいですか？'} do %>
+              <i class="fa-solid fa-trash-can recipe-delete"></i>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </article>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,15 +1,28 @@
 <div class="recipes-container flex">
   <aside class="px-2.5 md:pl-3 flex-left">
-    <%= render "recipes/shared/search_form", collection: @q %>
+    <% if user_signed_in? %>
+      <%= render "recipes/shared/search_form", collection: @q %>
+    <% else %>
+      <div class="commonCard-outstyle userInfo-wrapper p-2.5">
+        <p class="text-xl">レシピ検索</p>
+        <p class="text-sm mt-4">新規登録 or ログインをすると<span class="inline-block">レシピを検索できます</span></p>
+        <div class="text-center mt-8">
+          <%= link_to '新規登録', new_user_registration_path, class: 'login-btn leading-10' %>
+          <%= link_to 'ログイン', new_user_session_path, class: 'login-btn mt-4 leading-10' %>
+        </div>
+      </div>
+    <% end %>
   </aside>
 
   <main class="flex-center">
     <div class="recipeIndex-wrapper md:px-10 m-auto">
-      <% if current_user.characteristic == "general" || current_user.email == "guest@example.com" %>
-        <section class="px-6 mb-10 md:p-0">
-          <h2 class="mb-3.5 text-2xl">あなたへのおすすめ</h2>
-          <%= render "recipes/shared/recommend", recommend: @recommend, contributor: @contributor %>
-        </section>
+      <% if user_signed_in? %>
+        <% if current_user.characteristic == "general" || current_user.email == "guest@example.com" %>
+          <section class="px-6 mb-10 md:p-0">
+            <h2 class="mb-3.5 text-2xl">あなたへのおすすめ</h2>
+            <%= render "recipes/shared/recommend", recommend: @recommend, contributor: @contributor %>
+          </section>
+        <% end %>
       <% end %>
 
       <section>
@@ -34,9 +47,10 @@
     <% else %>
       <div class="commonCard-outstyle userInfo-wrapper p-2.5">
         <p class="text-xl">ユーザ情報</p>
-        <p class="text-sm mt-4">新規登録 or ログインをするとユーザ情報を表示します</p>
+        <p class="text-sm mt-4">新規登録 or ログインをすると<span class="inline-block">ユーザ情報を表示します</span></p>
         <div class="text-center mt-8">
-          <%= link_to 'ログイン', new_user_session_path, class: 'login-btn' %>
+          <%= link_to '新規登録', new_user_registration_path, class: 'login-btn leading-10' %>
+          <%= link_to 'ログイン', new_user_session_path, class: 'login-btn mt-4 leading-10' %>
         </div>
       </div>
     <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -5,7 +5,7 @@
 
   <main class="flex-center">
     <div class="recipeIndex-wrapper md:px-10 m-auto">
-      <% if current_user.characteristic == "general" %>
+      <% if current_user.characteristic == "general" || current_user.email == "guest@example.com" %>
         <section class="px-6 mb-10 md:p-0">
           <h2 class="mb-3.5 text-2xl">あなたへのおすすめ</h2>
           <%= render "recipes/shared/recommend", recommend: @recommend, contributor: @contributor %>

--- a/app/views/recipes/shared/_makes_favorites.html.erb
+++ b/app/views/recipes/shared/_makes_favorites.html.erb
@@ -1,0 +1,17 @@
+<p id="recipe-<%= recipe.id %>" class="make-icon show-makeBtn index-rec-makeBtn rsp-makeIcon">
+  <% if recipe.maked_by?(current_user) %>
+    <%# =====「作ってみた!」を押している状態 ===== %>
+    <%= render "makes/make", recipe: recipe %>
+  <% else %>
+    <%# =====「作ってみた!」を押していない状態 ===== %>
+    <%= render "makes/nonmake", recipe: recipe %>
+  <% end %>
+</p>
+<%# ===== お気に入り機能 ===== %>
+<p id="favorite-<%= recipe.id %>" class="make-icon favorite-btn rsp-makeIcon">
+  <% if recipe.favorited_by?(current_user) %>
+    <%= render "favorites/favorite", recipe: recipe %>
+  <% else %>
+    <%= render "favorites/nonfavorite", recipe: recipe %>
+  <% end %>
+</p>

--- a/app/views/recipes/shared/_recommend.html.erb
+++ b/app/views/recipes/shared/_recommend.html.erb
@@ -33,25 +33,10 @@
         <%= truncate(recommend.content, omision: "...", length: 100) %>
       </div>
 
-      <div class="mt-auto flex justify-between items-center">
+      <div class="make-wrapper">
         <div class="flex">
-          <p id="recipe-<%= recommend.id %>" class="make-icon mr-4">
-            <% if recommend.maked_by?(current_user) %>
-              <%# 「作ってみた!」を押している状態 %>
-              <%= render "makes/make", recipe: recommend %>
-            <% else %>
-              <%# 「作ってみた!」を押していない状態 %>
-              <%= render "makes/nonmake", recipe: recommend %>
-            <% end %>
-          </p>
-          <%# ===== お気に入り機能 ===== %>
-          <p id="favorite-<%= recommend.id %>" class="make-icon favorite-btn">
-            <% if recommend.favorited_by?(current_user) %>
-              <%= render "favorites/favorite", recipe: recommend %>
-            <% else %>
-              <%= render "favorites/nonfavorite", recipe: recommend %>
-            <% end %>
-          </p>
+          <%# =====「作ってみた！」とお気に入りの部分テンプレート ===== %>
+          <%= render "recipes/shared/makes_favorites", recipe: recommend %>
         </div>
 
         <%= link_to recommend, class: "hover:text-quaternary" do %>
@@ -64,7 +49,7 @@
 <% else %>
   <div class="makes-info-wrapper">
     <p>
-      <i class="fa-solid fa-circle-info text-blue-700"></i> 「作ってみた！ <i class="fa-regular fa-thumbs-up"></i>」を複数回押すと、あなたにおすすめのレシピを表示します
+      <i class="fa-solid fa-circle-info text-blue-700"></i> 「作ってみた！ <i class="fa-regular fa-thumbs-up"></i>」を押すと、あなたにおすすめのレシピを表示します
     </p>
   </div>
 <% end %>

--- a/app/views/recipes/shared/_recommend.html.erb
+++ b/app/views/recipes/shared/_recommend.html.erb
@@ -1,5 +1,11 @@
 <% if recommend != nil %>
   <div class="recommend-wrapper commonCard-outstyle">
+    <%# =====スマートフォン時に表示する投稿者の情報===== %>
+    <div class="flex mb-2 sp-contributorInfo">
+      <%= image_tag check_user_profile_image(contributor), class: "user-profileImage mr-2" %>
+      <p><%= contributor.name %></p>
+    </div>
+
     <div class="flex-1">
       <% if recommend.menu_image.present? %>
         <%= image_tag recommend.menu_image.thumb.url, class: "recommed-img" %>
@@ -10,28 +16,50 @@
 
     <div class="flex-1 flex flex-col md:px-6">
       <p class="text-2xl mb-4"><%= recommend.title %></p>
-      <div class="cooking-info">
-        <p><%= recommend.cooking_time %>分</p>
-        <p><%= recommend.cooking_cost %>円</p>
-        <p><%= recommend.calorie %>kcal</p>
+      <div class="contributor-cooking">
+        <div class="hidden md:flex">
+          <%= image_tag check_user_profile_image(contributor), class: "user-profileImage mr-2" %>
+          <p><%= contributor.name %></p>
+        </div>
+
+        <div class="cooking-info">
+          <p><%= recommend.cooking_time %>分</p>
+          <p><%= recommend.cooking_cost %>円</p>
+          <p><%= recommend.calorie %>kcal</p>
+        </div>
       </div>
 
       <div class="mt-2 mb-4">
         <%= truncate(recommend.content, omision: "...", length: 100) %>
       </div>
 
-      <div class="mt-auto flex justify-between">
+      <div class="mt-auto flex justify-between items-center">
+        <div class="flex">
+          <p id="recipe-<%= recommend.id %>" class="make-icon mr-4">
+            <% if recommend.maked_by?(current_user) %>
+              <%# 「作ってみた!」を押している状態 %>
+              <%= render "makes/make", recipe: recommend %>
+            <% else %>
+              <%# 「作ってみた!」を押していない状態 %>
+              <%= render "makes/nonmake", recipe: recommend %>
+            <% end %>
+          </p>
+          <%# ===== お気に入り機能 ===== %>
+          <p id="favorite-<%= recommend.id %>" class="make-icon favorite-btn">
+            <% if recommend.favorited_by?(current_user) %>
+              <%= render "favorites/favorite", recipe: recommend %>
+            <% else %>
+              <%= render "favorites/nonfavorite", recipe: recommend %>
+            <% end %>
+          </p>
+        </div>
+
         <%= link_to recommend, class: "hover:text-quaternary" do %>
           <i class="fa-solid fa-caret-right"></i>  詳しく見る
         <% end %>
 
-        <div class="flex">
-          <%= image_tag check_user_profile_image(contributor), class: "user-profileImage mr-2" %>
-          <p><%= contributor.name %></p>
-        </div>
       </div>
     </div>
-
   </div>
 <% else %>
   <div class="makes-info-wrapper">

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -4,30 +4,15 @@
   <% end %>
   <div class="flex recipeDetaile-flex">
     <div class="makeRecipe-wrapper">
+      <%# =====「作ってみた！」とお気に入りの部分テンプレート ===== %>
       <% if current_user.id != @recipe.user_id %>
-        <p id="recipe-<%= @recipe.id %>" class="make-icon lg:mb-4">
-          <% if @recipe.maked_by?(current_user) %>
-            <%# 「作ってみた!」を押している状態 %>
-            <%= render "makes/make", recipe: @recipe %>
-          <% else %>
-            <%# 「作ってみた!」を押していない状態 %>
-            <%= render "makes/nonmake", recipe: @recipe %>
-          <% end %>
-        </p>
-        <%# ===== お気に入り機能 ===== %>
-        <p id="favorite-<%= @recipe.id %>" class="make-icon favorite-btn">
-          <% if @recipe.favorited_by?(current_user) %>
-            <%= render "favorites/favorite", recipe: @recipe %>
-          <% else %>
-            <%= render "favorites/nonfavorite", recipe: @recipe %>
-          <% end %>
-        </p>
+        <%= render "recipes/shared/makes_favorites", recipe: @recipe %>
       <% end %>
     </div>
 
     <div class="commonCard-outstyle recipe-card">
       <header>
-        <div class="flex justify-between items-center mb-2">
+        <div class="flex justify-between items-center">
           <p class="text-sm ml-2">
             投稿日 <%= l @recipe.created_at %>
             <% if @recipe.created_at != @recipe.updated_at %>
@@ -43,29 +28,13 @@
                 <i class="fa-solid fa-trash-can recipe-deleteIcon recipe-delete"></i>
               <% end %>
             <% else %>
-            <%# ===== sp/tb用 作ってみた/お気に入りボタン ===== %>
-              <p id="recipe-<%= @recipe.id %>" class="make-icon rsp-makeIcon mr-4">
-                <% if @recipe.maked_by?(current_user) %>
-                  <%# 「作ってみた!」を押している状態 %>
-                  <%= render "makes/make", recipe: @recipe %>
-                <% else %>
-                  <%# 「作ってみた!」を押していない状態 %>
-                  <%= render "makes/nonmake", recipe: @recipe %>
-                <% end %>
-              </p>
-              <%# ===== お気に入り機能 ===== %>
-              <p id="favorite-<%= @recipe.id %>" class="make-icon favorite-btn rsp-makeIcon">
-                <% if @recipe.favorited_by?(current_user) %>
-                  <%= render "favorites/favorite", recipe: @recipe %>
-                <% else %>
-                  <%= render "favorites/nonfavorite", recipe: @recipe %>
-                <% end %>
-              </p>
+              <%# ===== sp/tb用 作ってみた/お気に入りボタン ===== %>
+              <%= render "recipes/shared/makes_favorites", recipe: @recipe %>
             <% end %>
           </div>
         </div>
 
-        <div class="mb-8 ml-2 flex">
+        <div class="flex m-0 md:mb-8 md:ml-2">
           <%= image_tag check_user_profile_image(@contributor), class: "user-profileImage mr-2" %>
           <p><%= @contributor.name %></p>
         </div>
@@ -89,13 +58,15 @@
           <p class="text-xl"><%= @recipe.content %></p>
         </div>
 
-        <div class="mt-8">
-          <p>投稿者のサイトを訪れてみる</p>
-          <%= link_to @contributor.url, class: "hover:text-quaternary" do %>
-            <%= @contributor.url %>
-            <i class="fa-solid fa-arrow-up-right-from-square"></i>
-          <% end %>
-        </div>
+        <% if @contributor.url.present? %>
+          <div class="mt-8">
+            <p>投稿者のサイトを訪れてみる</p>
+            <%= link_to @contributor.url, class: "hover:text-quaternary" do %>
+              <%= @contributor.url %>
+              <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            <% end %>
+          </div>
+        <% end %>
       </section>
     </div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 # ====== 本番環境のレベル閾値投入処理 ======
 i = 2
 point = 30
+LevelSetting.create!(passing_level: 1, threshold: 0)
 50.times do
   LevelSetting.create!(passing_level: i, threshold: point)
   i += 1


### PR DESCRIPTION
## 実装内容

- ゲストログインでもレコメンドレシピを表示させたいため、`inxdex`アクション内を修正
    - レコメンドレシピを渡す処理は`Recipe`モデルで実施
- `recipes.scss`のリファクタリング
- 投稿者の名前やプロフィール画像をレシピ内に設置
- 本番環境用の`seeds.rb`を修正
- 「作ってみた！」とお気に入りが各所で使用させるため、部分テンプレート化
- スマートフォン時に他のページに遷移させやすくするため、ヘッダーを固定
- `autheticate_user!`メソッドが`recipes_controller`にしか定義されていなかったため、`application_controller`に移動。（本来はもっと早くから修正すべき！）
    - `homes`と`recipes`の`index`アクションは`except`で例外にした