### PR TITLE
レスポンシブスタイルの修正

### DIFF
--- a/app/assets/stylesheets/layouts/flash.scss
+++ b/app/assets/stylesheets/layouts/flash.scss
@@ -1,3 +1,19 @@
+@mixin tb {
+  @media screen and (min-width: 790px) and (max-width: 1030px) {
+    @content;
+  }
+}
+@mixin sp {
+  @media screen and (max-width: 790px) {
+    @content;
+  }
+}
+@mixin sp-tb {
+  @media screen and (max-width: 1030px) {
+    @content;
+  }
+}
+
 // *-*-* フラッシュのレイアウト *-*-*
 @mixin flash-animation {
   z-index: 1;
@@ -13,21 +29,8 @@
       transform: translateY(0);
     }
   }
-}
-
-@mixin tb {
-  @media screen and (min-width: 790px) and (max-width: 1030px) {
-    @content;
-  }
-}
-@mixin sp {
-  @media screen and (max-width: 790px) {
-    @content;
-  }
-}
-@mixin sp-tb {
-  @media screen and (max-width: 1030px) {
-    @content;
+  @include sp {
+    z-index: 5;
   }
 }
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,7 +18,9 @@
           <%= f.label :characteristic_general, "個人利用者", class: "mr-4" %>
           <span class="inline-block">
             <%= f.radio_button :characteristic, :corporation %>
-            <%= f.label :characteristic_corporation, "法人(個人農家/個人飲食店経営の方はこちら)" %>
+            <%= f.label :characteristic_corporation do %>
+              法人<span class="text-sm md:text-base">(個人農家/個人飲食店経営の方はこちら)</span>
+            <% end %>
           </span>
           <p class="text-sm">＊個人利用の場合、レシピを投稿できません。</p>
         </div>
@@ -59,7 +61,7 @@
           <div class="google">
             <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post do %>
               <i class="fa-brands fa-google"></i>
-              Googleアカウントでサインインする
+              <span class="text-sm md:text-base">Googleアカウントでサインインする</span>
             <% end %>
           </div>
         </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,7 +8,7 @@
         <a href="https://storyset.com/user" class="credit">User illustrations by Storyset</a>
       </div>
 
-      <div class="flex-1 px-8 pt-8">
+      <div class="flex-1 px-2 pt-6 md:p-8">
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
           <div class="field">
             <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレス", class: "pl-7" %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -8,7 +8,7 @@
       <div class="topMsg-wrapper">
         <div>
           <p class="top-msg">最高のレシピをあなたに。</p>
-          <p class="top-msg">達成感を持って毎日の料理が楽しくなります。</p>
+          <p class="top-msg">達成感を持って毎日の料理が<span class="inline-block">楽しくなります。</span></p>
         </div>
       </div>
     </div>
@@ -21,7 +21,9 @@
         <%= link_to 'ログイン', new_user_session_path, class: 'login-btn' %>
       </div>
       <div class="px-4">
-        <%= link_to 'ゲストログイン(閲覧用)', users_guest_sign_in_path, method: :post, class: 'login-btn-guest' %>
+        <%= link_to users_guest_sign_in_path, method: :post, class: 'login-btn-guest' do %>
+          ゲストログイン<span class="inline-block">(閲覧用)</span>
+        <% end %>
       </div>
     </div>
 
@@ -93,7 +95,7 @@
       </div>
 
       <div class="mt-8">
-        <div class="tail-toUser-msg">
+        <div class="mb-8 text-center md:tail-toUser-msg">
           <h3 class="main-section-heading3">個人農家/個人飲食店経営の方</h3>
         </div>
         <div class="flex justify-center">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,5 +3,5 @@
   <%= link_to "https://twitter.com/icanenrichlife7", class: "footer-twitter" do %>
     <i class="fa-brands fa-twitter text-white"></i> 管理人のTwitter
   <% end %>
-  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.0</p>
+  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.1</p>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <div class="commonCard-outstyle recipe-card">
-      <header>
+      <div>
         <div class="flex justify-between items-center">
           <p class="text-sm ml-2">
             投稿日 <%= l @recipe.created_at %>
@@ -45,7 +45,7 @@
         <div class="text-center">
           <h2 class="text-2xl m-3.5"><%= @recipe.title %></h2>
         </div>
-      </header>
+      </div>
       
       <section class="p-0 md:p-4">
         <div class="recipiSub_info">


### PR DESCRIPTION
## 実装内容

- フラッシュ発生時、ヘッダーに隠れてしまうため、最前列に配置(改善の余地あり)
- トップ画面、ログイン関連ページの文字配置が中途半端に改行されてしまっていたため修正
- 詳細ページで`header`タグを使用しており、元々の`header`タグについていたスタイルが適用されてしまっていたため修正