### PR TITLE
レシピ関連の各種修正　Feature/recipe modification 07

### DIFF
--- a/app/assets/stylesheets/ranks.scss
+++ b/app/assets/stylesheets/ranks.scss
@@ -67,6 +67,7 @@
         border-radius: 15px;
         width: 380px;
         height: 270px;
+        margin: 0 auto;
         @include sp {
           width: 320px;
           height: 240px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :search
-  PER_PAGE = 20
+  PER_PAGE = 10
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,5 +3,5 @@
   <%= link_to "https://twitter.com/icanenrichlife7", class: "footer-twitter" do %>
     <i class="fa-brands fa-twitter text-white"></i> 管理人のTwitter
   <% end %>
-  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.4</p>
+  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.5</p>
 </div>

--- a/app/views/recipes/shared/_recommend.html.erb
+++ b/app/views/recipes/shared/_recommend.html.erb
@@ -1,5 +1,5 @@
 <% if recommend != nil %>
-  <div class="recommend-wrapper commonCard-outstyle">
+  <div class="recommend-wrapper commonCard-outstyle items-center">
     <%# =====スマートフォン時に表示する投稿者の情報===== %>
     <div class="flex mb-2 sp-contributorInfo">
       <%= image_tag check_user_profile_image(contributor), class: "user-profileImage mr-2" %>


### PR DESCRIPTION
## 実装内容

- ページネーションの表示レシピ数を20 => 10に変更。理由としてはレンダーのネスト化によってレンダー読み込み回数が多いため。
- レコメンド、ランキングのレシピカードが横向きにより、タイトルが長くなる場合、料理イメージとレシピ情報のバランスが悪くなり見栄えもよくないため、配置を修正
- `User`モデルへのアップデート処理が3回も行われていたため、1回の処理で済むように`level_setting.rb`内をリファクタリング