### PR TITLE
レシピ関連ページの修正

### DIFF
--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -51,6 +51,7 @@
 .searchForm-btn {
   @include submit-btn;
 }
+// ===== レシピの調理時間、調理コスト、カロリーのスタイル =====
 .cooking-info {
   @include flex-style(right, normal);
   p {
@@ -59,11 +60,25 @@
     margin: 0 4px;
   }
 }
+
 .make-wrapper {
   @include flex-style(space-between, center);
   margin-top: auto;
   .index-rec-makeBtn {
     margin-right: 16px;
+  }
+  .makes-link {
+    width: 40px;
+    height: 40px;
+    padding: 3px 0;
+    text-align: center;
+  }
+}
+// =====「詳しくみる」のスタイル =====
+.recipe-moreInfo {
+  min-width: 100px;
+  &:hover {
+    color: #aee6e6;
   }
 }
 .recipeArticle-content {

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,5 +3,5 @@
   <%= link_to "https://twitter.com/icanenrichlife7", class: "footer-twitter" do %>
     <i class="fa-brands fa-twitter text-white"></i> 管理人のTwitter
   <% end %>
-  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.5</p>
+  <p class="text-xs text-gray-500">©︎ 2022 FunCooApp:iloveomelette - v2.6.7</p>
 </div>

--- a/app/views/makes/_nonmake.html.erb
+++ b/app/views/makes/_nonmake.html.erb
@@ -1,5 +1,5 @@
 <%# 「作ってみた!」を押していない状態 %>
-<%= link_to recipe_makes_path(recipe), method: :post, remote: true, data: { confirm: 'このアクションを取り消すことはできませんが、よろしいですか？'} do %>
+<%= link_to recipe_makes_path(recipe), method: :post, remote: true, data: { confirm: 'このアクションを取り消すことはできませんが、よろしいですか？'}, class: "makes-link" do %>
   <i class="fa-regular fa-thumbs-up"></i>
   <%= recipe.makes_count %>
 <% end %>

--- a/app/views/recipes/_recipe.html.erb
+++ b/app/views/recipes/_recipe.html.erb
@@ -36,7 +36,7 @@
           </div>
         <% end %>
 
-        <%= link_to recipe, class: "text-base hover:text-quaternary" do %>
+        <%= link_to recipe, class: "recipe-moreInfo text-base" do %>
           <i class="fa-solid fa-caret-right"></i>  詳しく見る
         <% end %>
 

--- a/app/views/recipes/shared/_recommend.html.erb
+++ b/app/views/recipes/shared/_recommend.html.erb
@@ -39,7 +39,7 @@
           <%= render "recipes/shared/makes_favorites", recipe: recommend %>
         </div>
 
-        <%= link_to recommend, class: "hover:text-quaternary" do %>
+        <%= link_to recommend, class: "recipe-moreInfo" do %>
           <i class="fa-solid fa-caret-right"></i>  詳しく見る
         <% end %>
 

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -16,9 +16,10 @@
           <p class="text-sm ml-2">
             投稿日 <%= l @recipe.created_at %>
             <% if @recipe.created_at != @recipe.updated_at %>
-              <span class="ml-2">更新日 <%= l @recipe.updated_at %></span>
+              <span class="ml-2 inline-block">更新日 <%= l @recipe.updated_at %></span>
             <% end %>
           </p>
+
           <div class="flex">
             <% if current_user.id == @recipe.user_id %>
               <%= link_to edit_recipe_path(@recipe) do %>
@@ -34,10 +35,12 @@
           </div>
         </div>
 
-        <div class="flex m-0 md:mb-8 md:ml-2">
-          <%= image_tag check_user_profile_image(@contributor), class: "user-profileImage mr-2" %>
-          <p><%= @contributor.name %></p>
-        </div>
+        <%= link_to user_path(@contributor) do %>
+          <div class="flex m-0 md:mb-8 md:ml-2">
+            <%= image_tag check_user_profile_image(@contributor), class: "user-profileImage mr-2" %>
+            <p><%= @contributor.name %></p>
+          </div>
+        <% end %>
         
         <div>
           <%= image_tag @recipe.menu_image.url, class: "show-menuImg" %>
@@ -61,7 +64,7 @@
         <% if @contributor.url.present? %>
           <div class="mt-8">
             <p>投稿者のサイトを訪れてみる</p>
-            <%= link_to @contributor.url, class: "hover:text-quaternary" do %>
+            <%= link_to @contributor.url, target: "_blank", rel: "noopener noreferrer", class: "hover:text-quaternary" do %>
               <%= @contributor.url %>
               <i class="fa-solid fa-arrow-up-right-from-square"></i>
             <% end %>


### PR DESCRIPTION
## 実装内容

- 「作ってみた！」ボタンのレイアウトが崩れていたため(スマートフォン用)、修正
- 「詳しくみる」のレイアウトが崩れていたため、修正
- 詳細ページの投稿者画像と名前にその投稿者のページリンクを追加
- レシピカードのURLを新規タブで飛べるように修正