### PR TITLE
マジックナンバーを修正　Feature/magic number task

### DIFF
--- a/app/controllers/ranks_controller.rb
+++ b/app/controllers/ranks_controller.rb
@@ -1,6 +1,7 @@
 class RanksController < ApplicationController
+  TOP_FIVE_RANKINGS = 5
   def maked_ranking
-    recipe_ids = Recipe.order(makes_count: :desc).limit(5).pluck(:id)
+    recipe_ids = Recipe.order(makes_count: :desc).limit(TOP_FIVE_RANKINGS).pluck(:id)
     @high_rank_recipes = Recipe.includes(:makes, :favorites).find(recipe_ids)
   end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,4 +1,5 @@
 class Recipe < ApplicationRecord
+  LATEST_RECIPE = 1  # ===== レコメンドレシピを渡す処理で使用 =====
   belongs_to :user
   has_many :makes, dependent: :destroy
   has_many :maked_users, through: :makes, source: :user
@@ -31,7 +32,7 @@ class Recipe < ApplicationRecord
       if current_user.characteristic == "general"
         Recipe.find_by(id: recommend_recipe_id)
       elsif current_user.email == "guest@example.com"
-        Recipe.find_by(id: Recipe.order(created_at: :desc).limit(1).pluck(:id))
+        Recipe.find_by(id: Recipe.order(created_at: :desc).limit(LATEST_RECIPE).pluck(:id))
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   GUEST_USER_INTRODUCTION = "FunCooAppをご利用いただき誠にありがとうございます!\n 引き続き当アプリをお楽しみくださいませ。".freeze
+  PASSWORD_LENGTH = 10
   has_many :recipes, dependent: :destroy
   has_many :makes, dependent: :destroy
   has_many :maked_recipes, through: :makes, source: :recipe
@@ -72,7 +73,7 @@ class User < ApplicationRecord
           name: auth.info.name,
           email: auth.info.email,
           profile_image: auth.info.image,
-          password: Devise.friendly_token(10)
+          password: Devise.friendly_token(PASSWORD_LENGTH)
         )
         sns = SnsCredential.create(
           user_id: user.id,
@@ -90,7 +91,7 @@ class User < ApplicationRecord
           name: auth.info.name,
           email: auth.info.email,
           profile_image: auth.info.image,
-          password: Devise.friendly_token(10)
+          password: Devise.friendly_token(PASSWORD_LENGTH)
         )
       end
       { user: }


### PR DESCRIPTION
## 実装内容

- 以下の箇所で処理の引数が数値のままのため、定数に書き換えを実施
    - `ranks`コントローラのレシピ取得数
    - `recipe`モデルのゲストユーザ時に最新のレシピを取得する引数
    - `recommend`モデルの比較対象ユーザ数とログインユーザが「作ってみた」を押す前までのレコードから開始
    - `recommend`モデルのおすすめ候補のレシピ数
    - `recommend`モデルの通常時以外の処理における代わりのレシピID数
    - `user`モデルのセキュアなパスワードを生成する文字数