### PR TITLE
投稿編集・更新・削除のテスト　Feature/rspec task 02

### DIFF
--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -138,4 +138,46 @@ RSpec.describe "Recipes", type: :request do
       end
     end
   end
+
+  # ===== ここから更新のテスト =====
+  describe "POST #update" do
+    subject { patch(recipe_path(recipe.id, params:)) }
+    let!(:user) { create(:user) }
+    let!(:recipe) { create(:recipe, user_id: user.id) }
+    let!(:genre) { create(:genre, recipe_id: recipe.id) }
+    let(:params) { { make_recipe_form: attributes_for(:recipe).merge(new_genre) } }
+    let(:new_genre) { attributes_for(:genre) }
+
+    context "レシピIDを渡してリクエストを投げたとき" do
+      it "リクエストが成功する" do
+        sign_in user
+        subject
+        expect(response).to have_http_status(:found)
+      end
+    end
+
+    context "正常なパラメータを渡して『レシピ』を更新するとき" do
+      # ===== レシピのタイトルを更新前と更新後で比較する =====
+      it "レシピを更新した後、詳細ページにリダイレクトする" do
+        sign_in user
+        original_title = recipe.title
+        new_title = params[:make_recipe_form][:title]
+        expect { subject }.to change { recipe.reload.title }.from(original_title).to(new_title)
+        expect(response).to redirect_to Recipe.last
+      end
+    end
+
+    context "正常なパラメータを渡して『レシピのジャンル』を更新するとき" do
+      let(:new_genre) { attributes_for(:genre, staple_food: "noodles") }
+
+      # ===== ジャンルの主食を更新前と更新後で比較する =====
+      it "レシピを更新した後、詳細ページにリダイレクトする" do
+        sign_in user
+        original_staple_food = recipe.genre.staple_food
+        new_staple_food = params[:make_recipe_form][:staple_food]
+        expect { subject }.to change { recipe.genre.reload.staple_food }.from(original_staple_food).to(new_staple_food)
+        expect(response).to redirect_to Recipe.last
+      end
+    end
+  end
 end

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Recipes", type: :request do
-  # ===== ここから一覧ページのテスト =====
+  # ===== ここから一覧のテスト =====
   describe "GET #index" do
     subject { get(recipes_path) }
 
@@ -24,7 +24,7 @@ RSpec.describe "Recipes", type: :request do
     end
   end
 
-  # ===== ここから詳細ページのテスト =====
+  # ===== ここから詳細のテスト =====
   describe "GET #show" do
     subject { get(recipe_path(recipe_id)) }
     let(:user) { create(:user) }
@@ -67,7 +67,7 @@ RSpec.describe "Recipes", type: :request do
     end
   end
 
-  # ===== ここから新規投稿ページのテスト =====
+  # ===== ここから新規投稿のテスト =====
   describe "GET #new" do
     subject { get(new_recipe_path) }
     let(:user) { create(:user) }
@@ -108,6 +108,33 @@ RSpec.describe "Recipes", type: :request do
         sign_in user
         expect { subject }.not_to change(Recipe, :count)
         expect(response.body).to include "ジャンルを選択"
+      end
+    end
+  end
+
+  # ===== ここから編集のテスト =====
+  describe "GET #edit" do
+    subject { get(edit_recipe_path(recipe.id)) }
+    let!(:user) { create(:user) }
+    let!(:recipe) { create(:recipe, user_id: user.id) }
+    let!(:genre) { create(:genre, recipe_id: recipe.id) }
+
+    context "リクエストを投げたとき" do
+      it "リクエストが成功する" do
+        sign_in user
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "レシピが存在するとき" do
+      it "レシピのタイトル・コンテンツ・調理時間・目安費用・カロリーが表示される" do
+        sign_in user
+        subject
+        expect(response.body).to include(
+          recipe.title, recipe.content, recipe.cooking_time.to_s,
+          recipe.cooking_cost.to_s, recipe.calorie.to_s
+        )
       end
     end
   end


### PR DESCRIPTION
## 実装内容

- `GET #edit`
    - リクエストを投げて`200`を確認
    - ビューにレシピパラメータが表示されるかを確認
- `POST #update`
    - リクエストを投げて`302`を確認
    - 正常なパラメータと不正なパラメータで更新できるかを確認
    - 不正なパラメータを渡して更新をしたときに更新できないことを確認
- `DELETE #destroy`
    - 正常なパラメータを渡したときにフラッシュメッセージの表示、一覧ページへのリダイレクトを確認
    - 他人のレシピを削除しようとするとフラッシュメッセージの表示(アラート)、一覧ページへのリダイレクトを確認